### PR TITLE
chore: release v0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,11 +9,15 @@
   "plugins": [
     {
       "name": "flokay",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "source": "./",
       "description": "A curated, spec-driven development workflow — proposal, design, specs, tasks, review, implement.",
       "license": "MIT",
-      "keywords": ["workflow", "spec-driven", "development"],
+      "keywords": [
+        "workflow",
+        "spec-driven",
+        "development"
+      ],
       "repository": "https://github.com/pacaplan/flokay"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flokay",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A curated, spec-driven development workflow — proposal, design, specs, tasks, review, implement.",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # flokay
 
+## 0.2.1
+
+### Patch Changes
+
+- [#10](https://github.com/pacaplan/flokay/pull/10) Fix assorted bugs across skills and the plugin, including inline GraphQL values in fix-pr to avoid shell stripping, correct project path dots for subagent transcript lookup, and clarify the review artifact as a pre-implementation change review.
+
+
 ## 0.2.0
 
 ### Minor Changes

--- a/skills/implement-task/implementer-prompt.md
+++ b/skills/implement-task/implementer-prompt.md
@@ -52,7 +52,7 @@ After self-review passes:
    <the actual path of the task file>
    ```
 
-2. **Run gauntlet**: Use the `gauntlet-run` skill to validate changes.
+2. **Run gauntlet**: Use the `gauntlet-run` skill to validate changes. Tell it to enable the `task-compliance` review.
 
 3. **Handle results**:
    - **All gates pass**: Proceed to report


### PR DESCRIPTION
## Release v0.2.1

This PR was generated by the `/release` skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GraphQL value handling in PR fixes to prevent data loss
  * Corrected subagent transcript lookup path resolution
  * Clarified review artifact status in pre-implementation workflows

* **Chores**
  * Version bump to 0.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->