### PR TITLE
feat: rename plugin to codagent and embed artifact templates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "codagent",
   "owner": {
-    "name": "pacaplan"
+    "name": "Codagent-AI"
   },
   "metadata": {
     "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship."

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-skills",
+  "name": "codagent",
   "owner": {
     "name": "pacaplan"
   },
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "agent-skills",
+      "name": "codagent",
       "version": "0.5.0",
       "source": "./",
       "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "agent-skills",
-  "displayName": "Agent Skills",
+  "name": "codagent",
+  "displayName": "Codagent",
   "version": "0.5.0",
   "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
   "author": "pacaplan",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codagent",
-  "displayName": "Codagent",
+  "displayName": "Codagent Agent Skills",
   "version": "0.5.0",
   "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
   "author": "pacaplan",

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-gauntlet_logs
+validator_logs
 .agents

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Agent Skills
+# Codagent
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CodeRabbit](https://img.shields.io/coderabbit/prs/github/Codagent-AI/agent-skills)](https://coderabbit.ai)
 
 ## Overview
 
-Agent Skills is a plugin for Claude Code and Cursor that provides a set of focused skills for each stage of software development — from evaluating an idea to implementing with subagents to shepherding a PR through CI. Inspired by [obra/superpowers](https://github.com/obra/superpowers).
+Codagent is a plugin for Claude Code and Cursor that provides a set of focused skills for each stage of software development — from evaluating an idea to implementing with subagents to shepherding a PR through CI. Inspired by [obra/superpowers](https://github.com/obra/superpowers).
 
-![Agent Skills demo](docs/images/demo2.gif)
+![Codagent demo](docs/images/demo2.gif)
 
 ## Features
 
@@ -20,7 +20,7 @@ Agent Skills is a plugin for Claude Code and Cursor that provides a set of focus
 
 ## Prerequisites
 
-Agent Skills requires the Agent Validator CLI for automated quality verification:
+Codagent requires the Agent Validator CLI for automated quality verification:
 
 - **Agent Validator CLI** — install: `npm install -g agent-validator`
 - Then run `agent-validator init` in your project to configure the validator
@@ -29,11 +29,11 @@ Agent Skills requires the Agent Validator CLI for automated quality verification
 
 ### Claude Code
 
-Add the Agent Skills marketplace and install the plugin:
+Add the codagent marketplace and install the plugin:
 
 ```bash
 claude plugin marketplace add Codagent-AI/agent-skills
-claude plugin install agent-skills
+claude plugin install codagent
 ```
 
 ### Cursor
@@ -46,22 +46,22 @@ cursor plugins install Codagent-AI/agent-skills
 
 ### Initialize
 
-After installing with either runtime, initialize Agent Skills in your project:
+After installing with either runtime, initialize Codagent in your project:
 
 ```text
-/agent-skills:init
+/codagent:init
 ```
 
 ## Updating
 
 ```bash
-claude plugin marketplace update agent-skills
-claude plugin update agent-skills@agent-skills
+claude plugin marketplace update codagent
+claude plugin update codagent@codagent
 ```
 
 Then run to get the latest skills:
 ```text
-/agent-skills:init
+/codagent:init
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Codagent
+# Codagent Agent Skills
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CodeRabbit](https://img.shields.io/coderabbit/prs/github/Codagent-AI/agent-skills)](https://coderabbit.ai)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Agent Skills is a plugin for Claude Code and Cursor that provides a set of focus
 
 Agent Skills requires the Agent Validator CLI for automated quality verification:
 
-- **Agent Validator CLI** — install: `npm install -g @pacaplan/agent-validator`
+- **Agent Validator CLI** — install: `npm install -g agent-validator`
 - Then run `agent-validator init` in your project to configure the validator
 
 ## Installation

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,9 +5,9 @@
 To test the plugin from another project on the same machine:
 
 ```bash
-claude plugin uninstall agent-skills
+claude plugin uninstall codagent
 claude plugin marketplace add /path/to/agent-skills
-claude plugin install agent-skills
+claude plugin install codagent
 ```
 
 ### Refreshing after changes
@@ -15,7 +15,7 @@ claude plugin install agent-skills
 Installed plugins are cached at `~/.claude/plugins/cache/`. Edits to your local source files are **not** picked up automatically. After making changes, clear the cache and reinstall:
 
 ```bash
-rm -rf ~/.claude/plugins/cache/agent-skills
+rm -rf ~/.claude/plugins/cache/codagent
 ```
 
 Then start a new Claude session — the plugin will be re-cached from your local directory.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -63,7 +63,7 @@ digraph design {
 ## The Process
 
 **Reading the specs:**
-- If you wrote the specs earlier in this session, you already have context — only re-read if you need to check exact wording
+- If specs were written earlier in this session, re-read only to confirm exact wording
 - Otherwise, read all `specs/**/*.md` files in the change directory
 - Understand the settled requirements and any `<!-- deferred-to-design: ... -->` markers
 - Deferred markers are explicit invitations to complete or revise those scenarios once you have architectural context

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -30,13 +30,13 @@ If you discover a gap in the specs during the design conversation, surface it as
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Read all spec files** — read every file in the change's `specs/` directory before asking any architecture questions
-2. **Explore project context** — check files, docs, recent commits
+1. **Read all spec files** — read every file in the change's `specs/` directory before asking any architecture questions. Skip any you just wrote in this session.
+2. **Explore project context** — read the specific files, modules, and interfaces that the spec requirements will touch. Skip areas you already explored during earlier steps in this session.
 3. **Ask clarifying questions** — one at a time, about architecture, patterns, and technical trade-offs only
 4. **Track spec implications** — when an architectural decision reveals a new requirement or changes a scenario, note it
 5. **Propose 2-3 approaches** — with trade-offs and a recommendation
 6. **Present design** — in sections scaled to their complexity, get user approval after each section
-7. **Write the design document and apply spec edits** — write design.md to the outputPath provided, then edit any spec files identified during the conversation
+7. **Write the design document and apply spec edits** — write `design.md` in the change directory, then edit any spec files identified during the conversation
 
 ## Process Flow
 
@@ -63,12 +63,14 @@ digraph design {
 ## The Process
 
 **Reading the specs:**
-- Before asking any questions, read all `specs/**/*.md` files in the change directory
+- If you wrote the specs earlier in this session, you already have context — only re-read if you need to check exact wording
+- Otherwise, read all `specs/**/*.md` files in the change directory
 - Understand the settled requirements and any `<!-- deferred-to-design: ... -->` markers
 - Deferred markers are explicit invitations to complete or revise those scenarios once you have architectural context
 
 **Understanding the context:**
-- Check out the current project state (files, docs, recent commits)
+- Focus on the specific files, modules, and interfaces that the spec requirements will touch
+- Skip areas you already explored in earlier steps of this session
 - Use the spec files as the authoritative source of requirements
 
 **Asking clarifying questions:**
@@ -97,7 +99,7 @@ digraph design {
 
 ## After Approval
 
-Write the design document to the outputPath provided. Use the template structure provided.
+Write the design document using the Artifact Template below.
 
 Then apply any spec edits identified during the conversation: add new scenarios, revise existing ones, or complete deferred-to-design scenarios. Edit the relevant spec files directly. Only add or revise scenarios — do not restructure the file.
 
@@ -114,3 +116,42 @@ This skill does not invoke other skills or manage sequencing.
 - **Explore alternatives** — Always propose 2-3 approaches before settling
 - **Incremental validation** — Present design, get approval before moving on
 - **Be flexible** — Go back and clarify when something doesn't make sense
+
+## Artifact Template
+
+Use this structure when writing `design.md`. Scale each section to its complexity — omit sections that don't apply, keep simple sections to a few sentences.
+
+```markdown
+## Context
+
+<!-- Background and current state -->
+
+## Goals / Non-Goals
+
+**Goals:**
+<!-- What this design aims to achieve -->
+
+**Non-Goals:**
+<!-- What is explicitly out of scope -->
+
+## Approach
+
+<!-- The design itself: components, how they interact, data flow.
+     Use diagrams where they help. This is the "what are we building" section. -->
+
+## Decisions
+
+<!-- Key design decisions and rationale -->
+
+## Risks / Trade-offs
+
+<!-- Known risks and trade-offs -->
+
+## Migration Plan
+
+<!-- Steps to deploy, rollback strategy (if applicable) -->
+
+## Open Questions
+
+<!-- Outstanding decisions or unknowns to resolve -->
+```

--- a/skills/finalize-pr/SKILL.md
+++ b/skills/finalize-pr/SKILL.md
@@ -3,10 +3,10 @@ description: >
   Orchestrates the full post-implementation loop: push PR → wait for CI → fix failures → repeat
   until CI passes or termination rules trigger a pause.
   This skill should be used when the user says "ship it", "finalize pr", "push and fix CI",
-  "push pr and wait for CI", or invokes "agent-skills:finalize-pr".
+  "push pr and wait for CI", or invokes "codagent:finalize-pr".
 ---
 
-# agent-skills:finalize-pr
+# codagent:finalize-pr
 
 Push the PR, wait for CI, fix any failures or review comments, and repeat until the PR is green — or pause when termination rules require human input.
 
@@ -14,13 +14,13 @@ Push the PR, wait for CI, fix any failures or review comments, and repeat until 
 
 ### Step 1 — Push the PR
 
-Invoke `agent-skills:push-pr` to commit, push, and create or update the pull request.
+Invoke `codagent:push-pr` to commit, push, and create or update the pull request.
 
 If push-pr fails (e.g. no remote, auth error), report the error and stop.
 
 ### Step 2 — Wait for CI
 
-Invoke `agent-skills:wait-ci` to poll CI status and gather review comments.
+Invoke `codagent:wait-ci` to poll CI status and gather review comments.
 
 The wait-ci skill returns one of four statuses:
 - `passed` — CI green, no blocking reviews, no PR comments
@@ -46,7 +46,7 @@ Check termination rules before attempting a fix:
 
 If neither termination rule applies:
 
-- Invoke `agent-skills:fix-pr` to address CI failures and/or review comments
+- Invoke `codagent:fix-pr` to address CI failures and/or review comments
 - Return to Step 2
 
 ### Failure tracking

--- a/skills/fix-pr/SKILL.md
+++ b/skills/fix-pr/SKILL.md
@@ -2,10 +2,10 @@
 description: >
   Fixes CI failures and review comments on the current branch's pull request by dispatching
   a fixer subagent, verifying with the validator, and pushing the fix. Use when the user says
-  "fix pr", "fix CI failures", "address review comments", or invokes "agent-skills:fix-pr".
+  "fix pr", "fix CI failures", "address review comments", or invokes "codagent:fix-pr".
 ---
 
-# agent-skills:fix-pr
+# codagent:fix-pr
 
 Fix CI failures and review comments on the current branch's PR by dispatching a fixer subagent with all failure context, verifying the fix with the validator, and pushing.
 
@@ -98,7 +98,7 @@ Fix CI failures and review comments on the current branch's PR by dispatching a 
 5. **Push the fix**
 
    If the validator passes:
-   - Run `agent-skills:push-pr` to commit and push the fix to the PR branch
+   - Run `codagent:push-pr` to commit and push the fix to the PR branch
 
 6. **Report results**
 
@@ -125,4 +125,4 @@ Fix CI failures and review comments on the current branch's PR by dispatching a 
 - Can be invoked standalone — gathers its own context from the current branch's PR
 - Addresses CI failures AND review comments in a single subagent pass
 - Does NOT push if the validator fails — enforces quality gate before updating the PR
-- After pushing, CI will re-run; caller should invoke `agent-skills:wait-ci` again
+- After pushing, CI will re-run; caller should invoke `codagent:wait-ci` again

--- a/skills/implement-task/SKILL.md
+++ b/skills/implement-task/SKILL.md
@@ -68,13 +68,6 @@ Orchestrate subagent-driven task implementation for a structured change.
    - If all done: "All tasks complete! Ready to archive."
    - If paused: explain why and show options
 
-5. **Cleanup** (only when all tasks are complete)
-
-   Delete the validator task context file:
-   ```bash
-   rm -f .validator/current-task-context.md
-   ```
-
 **Output Format**
 
 ```markdown

--- a/skills/implement-task/implementer-prompt.md
+++ b/skills/implement-task/implementer-prompt.md
@@ -43,39 +43,30 @@ If self-review finds issues, fix them before proceeding to the validator.
 
 After self-review passes, run the validator directly using the steps below. Do NOT invoke the `agent-validator:validator-run` skill — follow these instructions instead.
 
-1. **Write the task context file** at `.validator/current-task-context.md`:
-
-   ```markdown
-   # Current Task Context
-
-   ## Task File
-   <the actual path of the task file>
-   ```
-
-2. **Clean up stale lock** (safe — tasks are dispatched sequentially, never in parallel):
+1. **Clean up stale lock** (safe — tasks are dispatched sequentially, never in parallel):
    ```bash
    rm -f gauntlet_logs/.validator-run.lock
    ```
 
-3. **Run the validator with output captured to a file** (Bun can drop stdout/stderr during LLM review subprocesses, so always redirect to a file):
+2. **Run the validator with output captured to a file** (Bun can drop stdout/stderr during LLM review subprocesses, so always redirect to a file):
    ```bash
    agent-validator run --enable-review task-compliance > gauntlet_logs/_subagent-run.log 2>&1; printf 'GAUNTLET_EXIT=%s\n' "$?" >> gauntlet_logs/_subagent-run.log
    ```
    Use `Bash` with `timeout: 300000` (5 minutes). Do NOT use `run_in_background`.
 
-4. **Read the captured output** (this is the reliable path — do not rely on the Bash tool's stdout capture):
+3. **Read the captured output** (this is the reliable path — do not rely on the Bash tool's stdout capture):
    ```bash
    cat gauntlet_logs/_subagent-run.log
    ```
 
    CRITICAL: **Exit code 1 means "violations were found"** — the command ran successfully but detected issues that need fixing. This is NOT an infrastructure failure. Do NOT retry blindly — read the output to understand what needs fixing.
 
-5. **Check the `Status:` line** in the output and act accordingly:
+4. **Check the `Status:` line** in the output and act accordingly:
    - `Status: Passed` or `Status: Passed with warnings` → proceed to commit
    - `Status: Failed` → read the violation details from the output. For each violation:
      - **CHECK failures**: follow the fix instructions shown in the output
      - **REVIEW violations**: fix the code issue described in the violation. If a violation is clearly a false positive, note it in your report but do not block on it.
-     After fixing, re-run the validator by going back to step 3. **Maximum 3 retry attempts.**
+     After fixing, re-run the validator by going back to step 2. **Maximum 3 retry attempts.**
    - `Status: Retry limit exceeded` → stop and include the failure details in your report
    - **No `Status:` line found** → the output file may be empty (known Bun issue). Read the latest console log instead:
      ```bash

--- a/skills/implement-task/implementer-prompt.md
+++ b/skills/implement-task/implementer-prompt.md
@@ -10,7 +10,7 @@ The task file contains Goal, Background, Spec (with requirements and scenarios),
 
 ### TDD (Test-Driven Development) — mandatory for testable tasks
 
-If the task has behavioral scenarios or produces testable behavior, use the `agent-skills:test-driven-development` skill for TDD methodology.
+If the task has behavioral scenarios or produces testable behavior, use the `codagent:test-driven-development` skill for TDD methodology.
 
 **When to skip TDD**: Pure infrastructure tasks (writing markdown files, config files, prompt templates) where no meaningful automated test exists. You still perform self-review and run the validator even when skipping TDD.
 
@@ -72,7 +72,7 @@ After self-review passes, run the validator directly using the steps below. Do N
      ```bash
      ls -t gauntlet_logs/console.*.log 2>/dev/null | head -1 | xargs -r cat
      ```
-     If no console log exists either, re-run the command once more (go back to step 3).
+     If no console log exists either, re-run the command once more (go back to step 2).
 
 ## Commit
 

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -17,8 +17,8 @@ Set up Agent Skills in the current project. This skill is idempotent — safe to
 Check that the Agent Validator CLI is installed. If missing, tell the user what to install and stop.
 
 - `agent-validator` — run `agent-validator --version`.
-  - If not found: "Agent Validator CLI is required. Install with `npm install -g agent-validator`, then run `agent-validator init` in your project, then re-run `/agent-skills:init`."
-  - If found, extract the version number and verify it is **≥ 0.15**. If too old: "agent-validator 0.15 or higher is required (found \<version\>). Upgrade from https://github.com/pacaplan/agent-validator, then re-run `/agent-skills:init`."
+  - If not found: "Agent Validator CLI is required. Install with `npm install -g agent-validator`, then run `agent-validator init` in your project, then re-run `/codagent:init`."
+  - If found, extract the version number and verify it is **≥ 0.15**. If too old: "agent-validator 0.15 or higher is required (found \<version\>). Upgrade from https://github.com/pacaplan/agent-validator, then re-run `/codagent:init`."
 
 Use this shell snippet to compare versions:
 ```bash
@@ -26,10 +26,10 @@ version_gte() { [ "$(printf '%s\n' "$2" "$1" | sort -V | head -1)" = "$2" ]; }
 ```
 Example: `version_gte "$installed_version" "0.15"` returns true if `$installed_version` ≥ 0.15.
 
-If the CLI is missing or out of date, stop. The user must resolve it first, then resume `/agent-skills:init`.
+If the CLI is missing or out of date, stop. The user must resolve it first, then resume `/codagent:init`.
 
 **Validator config (check after CLI passes):**
-- `.validator/config.yml` must exist. If not found: "Validator config not found. Run `agent-validator init` in your project first, then re-run `/agent-skills:init`." Stop.
+- `.validator/config.yml` must exist. If not found: "Validator config not found. Run `agent-validator init` in your project first, then re-run `/codagent:init`." Stop.
 
 ### 2. Print Success
 
@@ -39,12 +39,12 @@ Print a summary:
 Agent Skills initialized successfully.
 
 Available skills:
-- /agent-skills:propose — evaluate an idea and write a proposal
-- /agent-skills:spec — interview-driven requirement discovery
-- /agent-skills:design — brainstorm architecture and write a design doc
-- /agent-skills:plan-tasks — break a change into scoped task files
-- /agent-skills:implement-task — dispatch subagents to implement tasks
-- /agent-skills:finalize-pr — push PR, wait for CI, fix failures
+- /codagent:propose — evaluate an idea and write a proposal
+- /codagent:spec — interview-driven requirement discovery
+- /codagent:design — brainstorm architecture and write a design doc
+- /codagent:plan-tasks — break a change into scoped task files
+- /codagent:implement-task — dispatch subagents to implement tasks
+- /codagent:finalize-pr — push PR, wait for CI, fix failures
 ```
 
 ### 3. Commit
@@ -53,6 +53,6 @@ Invoke `/agent-validator:validator-commit skip` to commit any scaffolding change
 
 ## Guardrails
 
-- Stop on missing or outdated prerequisites — tell user what to install/run and resume with `/agent-skills:init`
+- Stop on missing or outdated prerequisites — tell user what to install/run and resume with `/codagent:init`
 - Never overwrite `.validator/config.yml` — only add/update entry points and reviews
 - Use the hosting runtime's native mechanism to locate the plugin's root directory

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -17,7 +17,7 @@ Set up Agent Skills in the current project. This skill is idempotent — safe to
 Check that the Agent Validator CLI is installed. If missing, tell the user what to install and stop.
 
 - `agent-validator` — run `agent-validator --version`.
-  - If not found: "Agent Validator CLI is required. Install with `npm install -g @pacaplan/agent-validator`, then run `agent-validator init` in your project, then re-run `/agent-skills:init`."
+  - If not found: "Agent Validator CLI is required. Install with `npm install -g agent-validator`, then run `agent-validator init` in your project, then re-run `/agent-skills:init`."
   - If found, extract the version number and verify it is **≥ 0.15**. If too old: "agent-validator 0.15 or higher is required (found \<version\>). Upgrade from https://github.com/pacaplan/agent-validator, then re-run `/agent-skills:init`."
 
 Use this shell snippet to compare versions:
@@ -31,16 +31,7 @@ If the CLI is missing or out of date, stop. The user must resolve it first, then
 **Validator config (check after CLI passes):**
 - `.validator/config.yml` must exist. If not found: "Validator config not found. Run `agent-validator init` in your project first, then re-run `/agent-skills:init`." Stop.
 
-### 2. Update .gitignore
-
-Ensure `.validator/current-task-context.md` is listed in the consumer project's `.gitignore` (it is a transient working file that should never be committed).
-
-Append it only if not already present:
-```bash
-grep -qxF '.validator/current-task-context.md' .gitignore 2>/dev/null || echo '.validator/current-task-context.md' >> .gitignore
-```
-
-### 3. Print Success
+### 2. Print Success
 
 Print a summary:
 
@@ -56,7 +47,7 @@ Available skills:
 - /agent-skills:finalize-pr — push PR, wait for CI, fix failures
 ```
 
-### 4. Commit
+### 3. Commit
 
 Invoke `/agent-validator:validator-commit skip` to commit any scaffolding changes. Checks are skipped because init only writes boilerplate.
 

--- a/skills/plan-tasks/SKILL.md
+++ b/skills/plan-tasks/SKILL.md
@@ -196,7 +196,7 @@ Order tasks so each one is ready to start when the previous finishes. A task is 
 
 ## 6. Write tasks.md
 
-With ordering settled, write the task index at `tasks.md` using the Artifact Template below.
+With ordering settled, write the task index at `<change-dir>/tasks.md` (i.e., in the change directory from Step 1) using the Artifact Template below.
 
 ## Artifact Template
 

--- a/skills/plan-tasks/SKILL.md
+++ b/skills/plan-tasks/SKILL.md
@@ -17,20 +17,20 @@ Assume the implementing subagent is a skilled developer with zero context about 
 ## 1. Read Your Inputs
 
 The following are provided:
-- `outputPath`: the change directory where all output goes (e.g. `changes/<name>/`)
-- `dependencies`: completed artifact files — `proposal.md`, `design.md`, and all `specs/**/*.md`
+- The change directory where all output goes (e.g. `changes/<name>/`)
+- Completed artifact files — `proposal.md`, `design.md`, and all `specs/**/*.md`
 
-Read all dependency files before proceeding.
+Read all artifact files before proceeding. Skip any you wrote earlier in this session — you already have that context.
 
 ---
 
 ## 2. Research the Codebase
 
-Explore the existing code relevant to this change. You need to understand:
-- Which files and modules will be touched
-- Current structure, interfaces, and conventions the implementation must follow
-- Whether any existing code is tangled or poorly abstracted enough that the new work would be significantly harder to implement as-is
-- Whether any existing documentation (README, guides, config references, etc.) will need updating as a result of this change
+Skip areas you already explored in earlier steps of this session. Focus on what's new or what you need to look at more closely for task planning. You need to understand:
+- Which specific files and modules will be touched by the change (use the design's Approach section to guide where to look)
+- Current structure, interfaces, and conventions in those files that the implementation must follow
+- Whether any of the affected code is tangled or poorly abstracted enough that the new work would be significantly harder to implement as-is
+- Whether any existing documentation (README, guides, config references, etc.) covering the affected areas will need updating
 
 **Decide now if a refactoring task is needed.** If implementation would require working around serious structural obstacles in the current code, you'll prepend a standalone refactoring task in Step 5. This task restructures existing code without changing behavior, so the feature work lands cleanly. It is not a default step — add it only when genuinely warranted. When in doubt, skip it; the implementing subagent can refactor inline as needed.
 
@@ -196,7 +196,9 @@ Order tasks so each one is ready to start when the previous finishes. A task is 
 
 ## 6. Write tasks.md
 
-With ordering settled, write the task index at `<outputPath>/tasks.md`.
+With ordering settled, write the task index at `tasks.md` using the Artifact Template below.
+
+## Artifact Template
 
 ```markdown
 - [ ] <Task title> (`tasks/<slug>.md`)

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -93,7 +93,7 @@ Present options when multiple approaches exist. Give a recommendation with reaso
 
 ### 5. Write the Proposal
 
-Once the idea has been evaluated and the approach has crystallized, write the proposal document following whatever format instructions you were given.
+Once the idea has been evaluated and the approach has crystallized, write `proposal.md` using the Artifact Template below.
 
 The proposal should be anchored in the "why" — the problem, the motivation, and the impact. Draw heavily from the Understand and Evaluate phases. The "what changes" section should scope the work without prescribing solutions.
 
@@ -104,4 +104,45 @@ The proposal should be anchored in the "why" — the problem, the motivation, an
 - **Do not go deep on implementation** — The proposal answers "why" and scopes "what". The "how" belongs entirely in design.md. Resist the urge to solve the problem in the proposal.
 - **Do not auto-transition** — Confirm with the user before writing the proposal. A "no-go" verdict means no proposal.
 - **Do visualize** — Diagrams help clarify thinking. Use them for architecture, comparisons, and flows.
-- **Proposal format lives in the template** — Do not hardcode proposal structure in this skill. Read and follow the template.
+- **Follow the template** — Use the Artifact Template section below for proposal structure.
+
+## Artifact Template
+
+Use this structure when writing `proposal.md`. Replace comments with actual content.
+
+```markdown
+## Why
+
+<!-- 1-2 sentences on the problem or opportunity. What problem does this solve? Why now? -->
+
+## What Changes
+
+<!-- Bullet list of changes. Be specific about new capabilities, modifications, or removals.
+     Mark breaking changes with **BREAKING**. -->
+
+## Capabilities
+
+<!-- This section is critical. It creates the contract between the proposal and specs phases.
+     Research existing specs before filling this in. Each capability listed here will need a
+     corresponding spec file. -->
+
+### New Capabilities
+<!-- Capabilities being introduced. Replace <name> with kebab-case identifier
+     (e.g., user-auth, data-export, api-rate-limiting). Each creates specs/<name>/spec.md -->
+- `<name>`: <brief description of what this capability covers>
+
+### Modified Capabilities
+<!-- Existing capabilities whose REQUIREMENTS are changing (not just implementation).
+     Only list here if spec-level behavior changes. Each needs a delta spec file.
+     Leave empty if no requirement changes. -->
+- `<existing-name>`: <what requirement is changing>
+
+## Out of Scope
+
+<!-- What is explicitly out of scope for this change. Be specific — vague exclusions
+     don't prevent scope creep. -->
+
+## Impact
+
+<!-- Affected code, APIs, dependencies, systems -->
+```

--- a/skills/push-pr/SKILL.md
+++ b/skills/push-pr/SKILL.md
@@ -1,10 +1,10 @@
 ---
 description: >
   Commits changes, pushes to remote, and creates or updates a pull request for the current branch.
-  Use when the user says "push pr", "create pr", "push and create pr", or invokes "agent-skills:push-pr".
+  Use when the user says "push pr", "create pr", "push and create pr", or invokes "codagent:push-pr".
 ---
 
-# agent-skills:push-pr
+# codagent:push-pr
 
 Commit all changes, push to the remote, and create or update the pull request for the current branch.
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -59,7 +59,7 @@ digraph spec {
 ## The Process
 
 **Reading the proposal:**
-- If you wrote the proposal earlier in this session, you already have context — skip re-reading it
+- If the proposal was written earlier in this session, skip re-reading unless exact wording needs verification
 - Otherwise, open the proposal's Capabilities section
 - Use the capability names to determine which spec files to create (one per capability)
 - Work through capabilities one at a time

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -24,11 +24,11 @@ Every capability needs its behavioral contract specified before design begins. E
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Read the proposal** — identify the Capabilities section and the list of capabilities to spec
+1. **Read the proposal** — identify the Capabilities section and the list of capabilities to spec. Skip if you just wrote the proposal in this session.
 2. **For each capability** — walk through the conversational requirement-discovery process:
    a. **Ask clarifying questions** — one at a time, understand behaviors, boundaries, error conditions, edge cases
    b. **Present spec sections for approval** — show the proposed requirements and scenarios, get user approval
-   c. **Write the spec file** — to the outputPath provided, using the template structure provided
+   c. **Write the spec file** — using the Artifact Template below
 3. **Write deferred-to-design markers** — for scenarios that depend on unresolved architectural choices
 
 ## Process Flow
@@ -59,7 +59,8 @@ digraph spec {
 ## The Process
 
 **Reading the proposal:**
-- Open the proposal's Capabilities section
+- If you wrote the proposal earlier in this session, you already have context — skip re-reading it
+- Otherwise, open the proposal's Capabilities section
 - Use the capability names to determine which spec files to create (one per capability)
 - Work through capabilities one at a time
 
@@ -82,8 +83,7 @@ digraph spec {
 - Be ready to go back and revise if something doesn't look right
 
 **Writing spec files:**
-- Write each spec file to the outputPath provided, using the template structure provided
-- The template defines the format rules (headers, scenario structure, delta operations)
+- Write each spec file using the Artifact Template below
 - Every requirement MUST have at least one scenario
 
 ## Deferred-to-Design Scenarios
@@ -104,3 +104,62 @@ Tell the user the relative path of each spec file created. This skill does not i
 - **Deferred is valid** — A deferred-to-design marker is better than a forced answer
 - **Incremental validation** — Present spec for each capability, get approval before writing
 - **Be flexible** — Go back and revise when something doesn't look right
+
+## Artifact Template
+
+Use this structure when writing spec files. Create one spec file per capability listed in the proposal's Capabilities section.
+
+- **New capabilities**: use the exact kebab-case name from the proposal (`specs/<capability>/spec.md`).
+- **Modified capabilities**: use the existing spec folder name when creating the delta spec.
+
+### Format rules
+
+- Each requirement: `### Requirement: <name>` followed by description
+- Use SHALL/MUST for normative requirements (avoid should/may)
+- Each scenario: `#### Scenario: <name>` with WHEN/THEN format
+- **Scenarios MUST use exactly 4 hashtags (`####`).** Using 3 or bullets will break parsing.
+- Every requirement MUST have at least one scenario
+
+### Abstraction level
+
+Scenarios describe observable behavioral contracts — what the system does when invoked under specific conditions. Focus on orchestration behavior (dispatch, gating, error handling, control flow), NOT file contents or internal structure.
+
+Write scenarios as behavioral contracts the capability guarantees to its callers:
+- GOOD: "WHEN subagent finds task ambiguous THEN it returns questions without implementing"
+- GOOD: "WHEN gauntlet retry limit is exhausted THEN subagent returns failure to coordinator"
+- BAD:  "WHEN SKILL.md is read THEN it contains TDD instructions"
+- BAD:  "WHEN config file exists THEN it has the correct YAML keys"
+
+### Delta operations
+
+Use `##` headers to categorize changes:
+
+- **ADDED Requirements** — New capabilities
+- **MODIFIED Requirements** — Changed behavior. MUST include full updated content.
+- **REMOVED Requirements** — Deprecated features. MUST include Reason and Migration.
+- **RENAMED Requirements** — Name changes only. Use FROM:/TO: format.
+
+When modifying existing requirements: if a prior spec file exists, copy the ENTIRE requirement block (from `### Requirement:` through all scenarios), paste under `## MODIFIED Requirements`, and edit to reflect new behavior. Using MODIFIED with partial content loses detail. If no prior spec file exists, investigate the existing code to understand current behavior, then write the full modified requirement (including all scenarios) as it should be after the change. If adding new concerns without changing existing behavior, use ADDED instead.
+
+### Template
+
+```markdown
+## ADDED Requirements
+
+### Requirement: <!-- requirement name -->
+<!-- requirement text -->
+
+#### Scenario: <!-- scenario name -->
+- **WHEN** <!-- condition -->
+- **THEN** <!-- expected outcome -->
+
+<!--
+  Example of additional delta sections:
+
+  ## REMOVED Requirements
+
+  ### Requirement: Legacy export
+  **Reason**: Replaced by new export system
+  **Migration**: Use new export endpoint at /api/v2/export
+-->
+```

--- a/skills/wait-ci/SKILL.md
+++ b/skills/wait-ci/SKILL.md
@@ -2,10 +2,10 @@
 description: >
   Polls CI check status for the current branch's pull request and reports pass/fail/pending/comments,
   surfacing PR review comments even when CI is green.
-  Use when the user says "wait for CI", "check CI", "poll CI", or invokes "agent-skills:wait-ci".
+  Use when the user says "wait for CI", "check CI", "poll CI", or invokes "codagent:wait-ci".
 ---
 
-# agent-skills:wait-ci
+# codagent:wait-ci
 
 Poll CI check status for the current branch's PR and report the result, enriching failures with log output and checking for blocking reviews.
 


### PR DESCRIPTION
## Summary

- Rename plugin from `agent-skills` to `codagent` across marketplace.json, plugin.json, README, and docs
- Embed artifact templates inline in `design`, `propose`, and `spec` SKILL.md files for self-contained workflow
- Fix install command and remove transient task context file from validator workflow
- Rewrite second-person phrasing in `design/SKILL.md` and `spec/SKILL.md` to imperative form

## Test plan

- [ ] Install plugin using `claude plugin install codagent` and verify it loads correctly
- [ ] Run `/codagent:init` in a test project and verify initialization succeeds
- [ ] Invoke `/agent-skills:design`, `/agent-skills:propose`, `/agent-skills:spec` and verify artifact templates are available inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed product from "Agent Skills" to "Codagent" in titles, examples, install/update and initialize commands.
  * Introduced a new Artifact Template for proposals, specs, designs, and tasks; tightened guidance to skip already-reviewed content and adjusted step ordering; removed a post-task cleanup step.
  * Updated example log/cache paths and CLI install package name.

* **Chores**
  * Updated plugin/manifest and metadata identifiers to use "Codagent".
  * Adjusted ignored log directory name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->