### PR TITLE
feat: add implement-change skill

### DIFF
--- a/.gauntlet/config.yml
+++ b/.gauntlet/config.yml
@@ -1,3 +1,6 @@
+debug_log:
+  enabled: true
+
 # Ordered list of CLI agents to try for reviews
 cli:
   default_preference:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Each skill is invoked with `/codagent:<skill-name>`.
 - **`design`** — Creates a technical design through collaborative brainstorming. Proposes 2-3 approaches with trade-offs, presents the design incrementally for approval, and writes `design.md`.
 - **`review-spec`** — Reviews design artifacts (proposal, specs, design, tasks) for internal consistency, cross-artifact alignment, and gaps. Reports findings with exact citations.
 - **`plan-tasks`** — Creates a structured task breakdown from the proposal, design, and specs. Each task file is self-contained with everything a subagent needs to implement it.
+- **`implement-change`** — Autonomous tech lead that implements a full change end-to-end. Dispatches one `implement-and-validate` subagent per task (sequentially, never in parallel), runs the gauntlet, archives the change, and finalizes the PR.
 - **`implement-with-tdd`** — Enforces test-driven development: write a failing test, watch it fail, write minimal code to pass, refactor. No production code without a failing test first.
 - **`implement-and-validate`** — Autonomous implementer that executes a single task end-to-end. Calls `implement-with-tdd` to build the code, performs self-review, runs the Agent Validator, and commits on success.
 - **`push-pr`** — Commits changes, pushes to remote, and creates or updates a pull request. Runs the validator before committing if applicable.

--- a/skills/implement-change/SKILL.md
+++ b/skills/implement-change/SKILL.md
@@ -1,0 +1,56 @@
+---
+description: >
+  Autonomous tech lead that implements a full change end-to-end by dispatching one subagent per task
+  sequentially using implement-and-validate, running the validator, and finalizing the PR. Activates
+  for requests like "implement this change", "apply the change", "ship it", or "execute the tasks".
+---
+
+Act as the tech lead for this work, overseeing implementor subagents who do the coding while
+remaining responsible for the successful completion of the deliverable.
+
+Review all provided tasks and context (design docs, specs, proposals, etc.) before starting —
+understanding the full scope upfront prevents costly mid-implementation surprises and ensures each
+subagent receives the right context. If anything is ambiguous or missing, ask before starting.
+
+## Execution
+
+Complete all tasks and get to a merged PR without requiring user intervention. Do not stop to ask
+permission, confirm next steps, or check in between tasks — make decisions and keep moving. The
+only valid reason to pause is a genuine blocker that cannot be resolved independently; in that
+case, surface it clearly and wait for guidance.
+
+### Step 1: Implement tasks
+
+Identify all incomplete tasks from the provided task list.
+
+Implement each task by invoking `codagent:implement-and-validate` as a subagent, one at a time.
+Pass the full task description along with all relevant context provided.
+
+Tasks run sequentially rather than in parallel because each one typically builds on the previous —
+parallel execution risks conflicts, ordering issues, and subagents stepping on each other's work.
+Wait for each subagent to complete and review its report before moving to the next task.
+
+If a subagent reports failure:
+- If the issue is fixable (environment problem, missing context), resolve it and retry.
+- If it's a genuine blocker that cannot be resolved, stop and surface it to the user.
+
+Mark each task complete before moving on.
+
+### Step 2: Run validator
+
+Run `agent-validator detect` to check for any code quality or compliance issues introduced during
+implementation.
+
+- If the only unverified change is a task-tracking file (e.g. checkbox edits), run
+  `agent-validator skip`.
+- Otherwise, run the full validator and fix any issues before proceeding.
+
+### Step 3: Archive change (if applicable)
+
+If using OpenSpec, invoke the `openspec-archive-change` skill to sync delta specs back to the main
+spec directory — do this automatically without prompting the user. Then run `agent-validator skip`.
+
+### Step 4: Finalize PR
+
+Invoke `codagent:finalize-pr` to push the PR, wait for CI, and fix any failures. It handles the
+full push → wait → fix loop automatically.

--- a/skills/implement-change/SKILL.md
+++ b/skills/implement-change/SKILL.md
@@ -30,9 +30,10 @@ Tasks run sequentially rather than in parallel because each one typically builds
 parallel execution risks conflicts, ordering issues, and subagents stepping on each other's work.
 Wait for each subagent to complete and review its report before moving to the next task.
 
-If a subagent reports failure:
-- If the issue is fixable (environment problem, missing context), resolve it and retry.
-- If it's a genuine blocker that cannot be resolved, stop and surface it to the user.
+If a subagent reports failure, check the failure report for the root cause:
+- **Missing context or clarification needed**: Provide the additional information and re-invoke the subagent.
+- **Retry limit exceeded after multiple attempts**: Review the failure details. If you can address the root cause (e.g., environment setup, a prerequisite task that wasn't complete), fix it and re-invoke once. Otherwise, surface it to the user.
+- **Immediate blocker** (contradictory requirements, missing dependency): Surface to the user immediately with the full blocker details.
 
 Mark each task complete before moving on.
 
@@ -48,7 +49,8 @@ implementation.
 ### Step 3: Archive change (if applicable)
 
 If using OpenSpec, invoke the `openspec-archive-change` skill to sync delta specs back to the main
-spec directory — do this automatically without prompting the user. Then run `agent-validator skip`.
+spec directory — do this automatically without prompting the user. Then run `agent-validator skip`
+(archiving is a file-reorganization operation that doesn't introduce code changes requiring validation).
 
 ### Step 4: Finalize PR
 

--- a/skills/implement-change/SKILL.md
+++ b/skills/implement-change/SKILL.md
@@ -39,12 +39,11 @@ Mark each task complete before moving on.
 
 ### Step 2: Run validator
 
-Run `agent-validator detect` to check for any code quality or compliance issues introduced during
-implementation.
+Run `agent-validator detect 2>&1` and branch on the exit code:
 
-- If the only unverified change is a task-tracking file (e.g. checkbox edits), run
-  `agent-validator skip`.
-- Otherwise, run the full validator and fix any issues before proceeding.
+- **Exit 0** → gates would run; invoke `agent-validator:validator-run` and wait for it to pass before proceeding.
+- **Exit 2** → no gates would run (no changes or no applicable gates, e.g. only task-tracking file edits); run `agent-validator skip` and proceed.
+- **Any other exit code** → error; surface the error output to the user and stop.
 
 ### Step 3: Archive change (if applicable)
 


### PR DESCRIPTION
Adds a new `implement-change` skill — an autonomous tech lead that implements a full change end-to-end.

## What it does
- Dispatches one `implement-and-validate` subagent per task, sequentially (never in parallel)
- Runs the validator after all tasks complete
- Optionally archives the change if using OpenSpec
- Finalizes the PR via `finalize-pr`

## Changes
- `skills/implement-change/SKILL.md` — new skill
- `README.md` — added skill to the skills list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an autonomous "implement-change" skill: reviews tasks up front, requests clarifications, executes tasks sequentially with retry/blocker handling, runs validation and remediation, optionally archives spec deltas, and finalizes the PR with CI-aware retry/fix loop.

* **Configuration**
  * Introduced a debug logging option (debug_log.enabled) to enable detailed debug output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->