### PR TITLE
Add handoff and review-assumptions skills, update session-report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Agent Skills — Development Notes
+
+## Skill frontmatter
+
+Do NOT add a `name` field to skill frontmatter. The `name` field overrides the skill's display prefix, causing it to show an incorrect or generic name instead of the proper namespaced prefix (e.g. `codagent:handoff`).

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,76 @@
+---
+description: >
+  Summarizes a specific aspect of the current conversation so another agent can resume.
+  Use when the user says "handoff", "summarize for handoff", "write a handoff", or wants to
+  capture context for another agent session. The user MUST specify what aspect to summarize
+  in their prompt (e.g., "handoff the debugging progress", "handoff the design decisions").
+---
+
+# Handoff
+
+Write a focused summary of a specific aspect of the current conversation so a fresh agent can pick up where this session left off.
+
+This is NOT a full conversation summary. The user's prompt tells you which aspect to capture. If the aspect is unclear, ask for clarification before proceeding.
+
+## What to capture
+
+For the aspect the user specified, write:
+
+1. **Objective** — What the user is trying to accomplish (the goal, not the history).
+2. **Current state** — Where things stand right now. What's done, what's in progress, what's blocked.
+3. **Key decisions** — Decisions made during this session that the next agent must honor, with brief rationale.
+4. **Open questions** — Unresolved issues, trade-offs still being weighed, or things the user hasn't decided yet.
+5. **Next steps** — Concrete actions the resuming agent should take first.
+6. **Relevant files** — Paths to files that were created, modified, or are central to the work.
+
+Omit any section that has nothing meaningful to say. Keep it tight — the resuming agent needs signal, not narration.
+
+## Output
+
+Write the summary to `handoff.md`.
+
+**Determining the output location:**
+
+1. If the user specified a path in their prompt, use it.
+2. If a project configuration (e.g., AGENTS.md, openspec config, or similar conventions) specifies a change directory, write there.
+3. Otherwise, determine the relevant change slug from context (the change being worked on, or a kebab-case slug from the topic) and write to `~/.agent-skills/changes/<slug>/handoff.md`.
+
+Do not ask the user to confirm the location. Just write to the resolved path.
+
+## Template
+
+```markdown
+# Handoff: <aspect being handed off>
+
+## Objective
+
+<!-- What the user is trying to accomplish -->
+
+## Current State
+
+<!-- Where things stand: done, in progress, blocked -->
+
+## Key Decisions
+
+<!-- Decisions made this session that the next agent must honor -->
+- **<decision>** — <rationale>
+
+## Open Questions
+
+<!-- Unresolved issues or trade-offs -->
+
+## Next Steps
+
+<!-- Concrete first actions for the resuming agent -->
+
+## Relevant Files
+
+<!-- Paths to files central to this work -->
+```
+
+## Guardrails
+
+- **Do not summarize the entire conversation.** Focus only on the aspect the user specified.
+- **Do not invent context.** Only capture what actually happened or was discussed in this session.
+- **Do not prescribe solutions for open questions.** State the question; let the next agent and user decide.
+- **Write for a cold reader.** The resuming agent has zero prior context — be precise about file paths, branch names, and terminology.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: handoff
 description: >
   Summarizes a specific aspect of the current conversation so another agent can resume.
   Use when the user says "handoff", "summarize for handoff", "write a handoff", or wants to

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: handoff
 description: >
   Summarizes a specific aspect of the current conversation so another agent can resume.
   Use when the user says "handoff", "summarize for handoff", "write a handoff", or wants to

--- a/skills/review-assumptions/SKILL.md
+++ b/skills/review-assumptions/SKILL.md
@@ -1,0 +1,85 @@
+---
+description: >
+  Review the risky/notable assumptions and context gaps surfaced by implementor session reports.
+  Fix high-confidence issues directly; ask the user one clarifying question at a time for
+  ambiguous ones.
+  Use when the user says "review assumptions", "audit implementor assumptions", or when invoked
+  by a workflow's assumption-review step.
+---
+
+# Review Assumptions
+
+The implementor(s) produced session report(s) (via `codagent:session-report`) listing `risky` / `notable` assumptions and context gaps. They did not have the plan's intent — you do. Audit the findings, act on what you're confident about, ask the user about what you're not.
+
+## Checklist
+
+Work through these in order:
+
+1. **Extract findings** via a subagent — keep extraction noise off your context.
+2. **Classify and act on each finding** one at a time.
+3. **Summarize** what was fixed, what the user decided, and any remaining context gaps.
+
+## Extracting findings
+
+Dispatch a subagent with this task:
+
+- From the session report(s), extract the `## Assumption Audit` (with `### Risky` / `### Notable` subsections) and `## Context Gaps` sections, and, if applicable, identify which task the report came from.
+- Return a compact markdown list: one line per finding with task, severity, and a verbatim quote of the bullet. No commentary.
+
+If nothing turns up, report "no findings to review" and stop.
+
+## Classifying and acting
+
+For each finding, pick one bucket and act accordingly:
+
+- **High-confidence fix** — a bug, obvious gap, or clear deviation from the plan. Fix it directly: edit (or dispatch an implementor subagent for nontrivial changes), then commit with a message citing the task and assumption. Don't ask permission.
+  - Examples: implementor picked a default that contradicts a spec scenario; implementor skipped an error path the spec required; implementor left a TODO the plan explicitly required finishing.
+- **Ambiguous** — product intent, scope, or UX preference only the user can weigh in on. Ask the user, then apply their answer.
+  - Examples: which of two reasonable naming choices; whether to widen scope for an adjacent edge case; whether a near-miss matches the spec's original intent.
+- **Acceptable** — fine against the plan. Note and move on.
+
+If a finding makes a claim about code ("I fixed X", "already handles Y"), have a subagent spot-check before classifying — don't take the implementor's word for it.
+
+If you're guessing, it's ambiguous. Calibrate your confidence bar honestly.
+
+<HARD-GATE>
+For ambiguous findings, ask **one question at a time** via the appropriate tool for requesting user input. Never batch. Finish one finding fully — including applying the user's answer — before raising the next.
+</HARD-GATE>
+
+Each clarifying question should:
+- Quote the assumption (or a tight paraphrase) so the user has context.
+- Cite the task and section it came from.
+- Propose 2–4 concrete options when the option space is small. Include "leave as-is" when appropriate.
+- Not presume the answer.
+
+After the user answers, apply the change exactly like a high-confidence fix (edit, commit) before moving on. If the answer is "leave as-is", note it and move on.
+
+## Context gaps
+
+Context gaps are feedback on the plan itself — missing information that sent an implementor down a wrong path. **Do not try to fix them.** Collect verbatim and surface in the final summary so the user can update the plan, spec, or future task generation.
+
+## Final summary
+
+End with one message structured as:
+
+```markdown
+## Review Summary
+
+### Fixed (high-confidence)
+- [task X] — [assumption] → [what you changed, commit sha]
+
+### Resolved with user
+- [task X] — [assumption] → [user's choice] → [what you changed, or "left as-is"]
+
+### Context gaps
+- [task X] — [gap, verbatim] — Missing: [what was needed]
+```
+
+Omit any section with zero items.
+
+## Guardrails
+
+- Scope is the flagged findings plus code spot-checks on claims — not a full re-review.
+- Don't lower the confidence bar to avoid asking. Silent drift from product intent is the failure mode this step exists to prevent.
+- Don't ask about findings you just fixed — fix first, then report what you fixed.
+- Trust the plan when a finding disagrees with it absent contrary evidence.

--- a/skills/review-assumptions/SKILL.md
+++ b/skills/review-assumptions/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: review-assumptions
 description: >
   Reviews risky/notable assumptions and context gaps surfaced by implementor session reports,
   fixes high-confidence issues directly, and asks one clarifying question at a time for

--- a/skills/review-assumptions/SKILL.md
+++ b/skills/review-assumptions/SKILL.md
@@ -1,15 +1,16 @@
 ---
+name: review-assumptions
 description: >
-  Review the risky/notable assumptions and context gaps surfaced by implementor session reports.
-  Fix high-confidence issues directly; ask the user one clarifying question at a time for
-  ambiguous ones.
+  Reviews risky/notable assumptions and context gaps surfaced by implementor session reports,
+  fixes high-confidence issues directly, and asks one clarifying question at a time for
+  ambiguous findings.
   Use when the user says "review assumptions", "audit implementor assumptions", or when invoked
   by a workflow's assumption-review step.
 ---
 
 # Review Assumptions
 
-The implementor(s) produced session report(s) (via `codagent:session-report`) listing `risky` / `notable` assumptions and context gaps. They did not have the plan's intent — you do. Audit the findings, act on what you're confident about, ask the user about what you're not.
+The implementor(s) produced session report(s) (via `codagent:session-report`) listing `risky` / `notable` assumptions and context gaps. Assume the implementors did not have the plan's intent; audit the findings against that intent, act on confident fixes, and ask about ambiguous cases.
 
 ## Checklist
 

--- a/skills/session-report/SKILL.md
+++ b/skills/session-report/SKILL.md
@@ -21,12 +21,12 @@ Identify every place you made a decision that was not dictated by the task file 
 - **Choice** — what you decided and why (the reasoning, not just the outcome)
 - **Risk** — what could go wrong if this choice is wrong. Be specific: name the scenario, the affected code path, and what would break. "Could surprise future workflows" is not specific enough — say which workflow shape triggers it and what the symptom would be.
 - **Impact classification**:
-  - `benign` — reasonable default, no real consequence
+  - `benign` — reasonable default, no real consequence (do not report)
   - `notable` — meaningful choice that could have gone differently
   - `risky` — could cause problems, warrants review
-- **Recommendation** (for `notable` and `risky` only) — what the reviewer should do: verify behavior, add a test, clarify the spec, or approve as-is with rationale.
+- **Recommendation** — what the reviewer should do: verify behavior, add a test, clarify the spec, or approve as-is with rationale.
 
-Surface all assumptions. Do not filter out benign ones. Sort by impact: `risky` first, then `notable`, then `benign`.
+Report only `risky` and `notable` assumptions. Drop `benign` entirely — they dilute the signal. Sort `risky` first, then `notable`.
 
 ### Dimension 2: Context Gaps
 
@@ -38,7 +38,6 @@ The bar is high. Most sessions have zero context gaps. Fixing a linter warning i
 - The task said to extend module X, but module X was deleted last week and replaced by module Y — you built against a nonexistent target
 - The task required integrating with service A but didn't mention that service A requires an auth token from a separate provisioning step — you couldn't have known this without tribal knowledge
 - The task file pointed you to the wrong directory or package, wasting significant effort before you found the right one
-- A critical requirement was completely absent from the task file and no automated check caught it — you only learned about it from the user after delivering
 
 **Things that are NOT context gaps (do not report these):**
 - Anything the validator caught (lint, security, permissions, test failures) — the validator's entire purpose is to catch what the task doesn't enumerate
@@ -69,16 +68,12 @@ For each genuine context gap:
    - **Risk:** [Specific scenario that breaks — name the code path, workflow shape, and symptom]
    - **Recommendation:** [What the reviewer should do]
 
-### Benign
-
-1. **[What the spec didn't say]** — [What you decided and why]
-
 ## Context Gaps
 
 - [What happened] — Missing context: [what was needed]
 ```
 
-Omit any section (`Risky`, `Notable`, `Benign`) that has zero items.
+Omit any section (`Risky`, `Notable`) that has zero items. Do not include a `Benign` section.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

- Adds `codagent:handoff` skill for summarizing a specific conversation aspect so a fresh agent can resume
- Adds `codagent:review-assumptions` skill for auditing risky/notable assumptions from implementor session reports
- Updates `codagent:session-report` to drop benign assumptions from output (they dilute signal)
- Adds `CLAUDE.md` documenting that skill frontmatter must not include a `name` field (breaks namespaced display prefix)

## Test plan

- [ ] Invoke `/codagent:handoff` and verify it asks for an aspect if not specified
- [ ] Invoke `/codagent:review-assumptions` after a session report and verify it processes risky/notable findings
- [ ] Verify neither skill shows an incorrect display prefix in the skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidelines for skill documentation formatting and best practices to ensure consistency

* **New Features**
  * Introduced handoff summary generation capability for creating targeted agent handoff documentation with structured content requirements
  * Introduced assumption review analysis skill for systematic assumption validation and context gap identification

* **Improvements**
  * Refined session analysis skill with updated assumption reporting rules and streamlined output formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->