### PR TITLE
Add ask-questions, handoff, and review-assumptions skills

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,9 +1,11 @@
 ---
 description: >-
-  Creates a release PR from merged PRs — gathers merged PRs since last tag,
-  calculates semver bump from conventional commit titles, generates changelog
-  entries, and opens a release PR. Use when the user says "release", "cut a
-  release", "create a release PR", "prepare a release", or "bump version".
+  Creates a release PR from merged PRs — gathers merged PRs since last tag
+  (plus any unmerged current-branch PR), calculates semver bump from
+  conventional commit titles, generates changelog entries, and opens a release
+  PR. Works from any branch: includes both main and current branch changes.
+  Use when the user says "release", "cut a release", "create a release PR",
+  "prepare a release", or "bump version".
 ---
 
 Create a release PR by gathering merged PRs, calculating the version bump, writing changelog entries, and opening the PR.

--- a/.claude/skills/release/scripts/release-info.sh
+++ b/.claude/skills/release/scripts/release-info.sh
@@ -3,19 +3,37 @@ set -euo pipefail
 
 # release-info.sh — Gather merged PRs, classify by type, calculate version bump.
 # Output: JSON with current_version, new_version, and PRs grouped by bump type.
+# Works from any branch: includes merged-to-main PRs AND the current branch's PR.
 
 REPO="Codagent-AI/agent-skills"
 PLUGIN_JSON=".claude-plugin/plugin.json"
 
-# --- Ensure clean main branch ---
+# --- Prepare working branch ---
 CURRENT_BRANCH=$(git branch --show-current)
-if [ "$CURRENT_BRANCH" != "main" ]; then
-  jq -n --arg branch "$CURRENT_BRANCH" '{"error": "not_on_main", "message": "Must be on main branch. Current branch: \($branch)"}' >&2
-  exit 1
-fi
+BRANCH_PR=""
+AHEAD=0
 
-git pull origin main --quiet
-git fetch --tags --quiet
+git fetch origin main --tags --quiet
+
+if [ "$CURRENT_BRANCH" = "main" ]; then
+  git pull origin main --quiet
+else
+  # Check for commits ahead of origin/main
+  AHEAD=$(git log --oneline origin/main..HEAD | wc -l | tr -d ' ')
+  if [ "$AHEAD" -gt 0 ]; then
+    # Verify a PR exists for this branch
+    BRANCH_PR=$(gh pr view --json number,title,labels 2>&1) || {
+      jq -n '{"error": "no_pr", "message": "Current branch has changes not on main but no PR exists. Create a PR first."}' >&2
+      exit 1
+    }
+  fi
+
+  # Merge origin/main into current branch
+  if ! git merge origin/main --no-edit --quiet 2>/dev/null; then
+    jq -n '{"error": "merge_conflict", "message": "Merge conflicts when merging origin/main. Resolve conflicts first."}' >&2
+    exit 1
+  fi
+fi
 
 # --- Find last release tag ---
 LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
@@ -36,6 +54,11 @@ fi
 PRS=$(gh pr list --repo "$REPO" --state merged --base main \
   --search "merged:>$TAG_DATE" \
   --json number,title,mergedAt,labels --limit 100)
+
+# --- Add current branch PR if not on main and has commits ahead ---
+if [ "$CURRENT_BRANCH" != "main" ] && [ "$AHEAD" -gt 0 ] && [ -n "$BRANCH_PR" ]; then
+  PRS=$(jq -s '.[0] + [.[1]] | unique_by(.number)' <(echo "$PRS") <(echo "$BRANCH_PR"))
+fi
 
 # --- Filter out release PRs and classify ---
 RESULT=$(echo "$PRS" | jq --arg cv "$CURRENT_VERSION" '

--- a/skills/ask-questions/SKILL.md
+++ b/skills/ask-questions/SKILL.md
@@ -1,0 +1,75 @@
+---
+description: >
+  How to ask users questions interactively: which tool to use, how to batch questions, and
+  when to ask serially. Follow this skill when asking clarifying questions, requesting
+  confirmation, collecting missing requirements, or pausing for user input.
+  Invoked by other skills rather than directly by the user.
+---
+
+# Ask Questions
+
+This skill encodes how to ask users questions effectively. It is **not invoked directly** by the user — it is invoked by other skills whenever they need to collect information through interactive dialogue.
+
+## Which Tool to Use
+
+**Always use the dedicated question/input tool, not a plain message.**
+
+- **Claude**: use the `mcp__ide__askQuestion` tool (or `ask_followup_question` in agentic contexts). Do NOT embed questions in plain prose — use the tool.
+- **Other agents**: use the equivalent input-requesting tool for your runtime (e.g., `request_input`, `ask_user`, or similar). If your runtime exposes a native question tool, always prefer it over a plain assistant turn.
+
+The tool ensures the agent explicitly waits for a response before continuing, rather than proceeding with assumptions.
+
+<HARD-GATE>
+NEVER ask a question by writing it in prose and continuing the response. ALWAYS use the appropriate question tool to pause and wait for the user's answer. Violating this is the most common failure mode.
+</HARD-GATE>
+
+## Batching Strategy
+
+**Prefer asking 2–4 questions at a time.** Batching reduces round-trips and respects the user's time.
+
+### When to batch (default)
+
+Group related questions into a single tool call when:
+- The questions are independent of each other (answering one doesn't change what you'd ask next)
+- They cover the same topic or decision area
+- 2–4 questions fit naturally together
+
+**Good batch example** (for a spec clarifying session):
+> 1. What happens when a user submits the form with an empty required field — validation error inline, or blocked on submit?
+> 2. Should validation run on blur (leaving the field) or only on submit?
+> 3. Are there any fields that should be optional in draft mode but required on final submit?
+
+### When to ask one question at a time (serial)
+
+Ask a single question only when:
+- The answer determines what the *next* question should be (a branching decision point)
+- The question is a binary gate that may end the conversation entirely (e.g., "Is this change approved?")
+
+**Good serial example:**
+> "Before I write the spec file, does this look right to you?" ← wait for yes/no before continuing
+
+Even when asking serially, use the question tool — not prose.
+
+### Anti-patterns
+
+- **Asking 1 question when 3 are independent** — unnecessarily drag out the conversation
+- **Asking 7 questions at once** — overwhelming; users stop reading carefully past question 3
+- **Embedding questions in prose** — the agent may not pause for a response; always use the tool
+- **Asking follow-up questions that ignore the dependency** — if Q1's answer eliminates Q3, drop Q3
+
+## Question Quality
+
+- **Prefer multiple-choice** when the option space is bounded — easier to answer quickly
+- **Open-ended is fine** when the space is genuinely open (e.g., "What should happen when X?")
+- **Provide context with each question** — quote relevant material if needed so the user isn't switching context
+- **One topic per question** — don't bundle two decisions into one question
+
+## Applying This Skill
+
+When another skill says "use the appropriate tool for asking the user a question or requesting input":
+
+1. Determine whether to batch or ask serially (see above)
+2. Draft your questions following the quality guidelines
+3. Call the question tool with all questions in this batch
+4. Wait for the user's response before proceeding
+5. Adjust your next batch based on what you learned

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -115,6 +115,8 @@ This skill does not invoke other skills or manage sequencing.
 - **Explore alternatives** — Always propose 2–3 approaches before settling
 - **Incremental validation** — Present design, get approval before moving on
 - **Be flexible** — Go back and clarify when something doesn't make sense
+- **Capture implementation details** — Implementation details that came up in conversation but don't belong in behavioral specs (algorithms, data-structure choices, integration points, migration steps, error-handling strategies, etc.) **must** be captured here
+- **Write for a different agent** — A separate implementing agent will read this design with no shared context from this conversation. Every decision, constraint, and technical detail must be in the written artifact
 
 ## Artifact Template
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -74,11 +74,9 @@ digraph design {
 - Use the spec files as the authoritative source of requirements
 
 **Asking clarifying questions:**
-- Use the appropriate tool for asking the user a question or requesting input for all questions and confirmations
-- Ask questions one at a time to clarify architecture, patterns, and trade-offs
-- Prefer multiple-choice questions when possible, but open-ended is fine too
-- Only one question per message — if a topic needs more exploration, break it into multiple questions
+- Follow the `codagent:ask-questions` skill for how to ask questions (tool to use, batching strategy, question quality)
 - Focus on: technical approach, architecture, patterns, trade-offs, constraints
+- Prefer multiple-choice questions when possible, but open-ended is fine too
 - Do NOT ask about what the system should do — that is settled in the specs
 
 **Tracking spec implications:**
@@ -111,10 +109,10 @@ This skill does not invoke other skills or manage sequencing.
 - **Read specs first** — Requirements are settled before this conversation begins
 - **Architecture only** — Ask about "how", not "what"
 - **Surface spec implications** — Don't silently ignore new requirements revealed by architecture
-- **One question at a time** — Don't overwhelm with multiple questions
+- **Use `codagent:ask-questions`** — For tool choice and batching strategy when gathering information
 - **Multiple choice preferred** — Easier to answer than open-ended when possible
 - **YAGNI ruthlessly** — Remove unnecessary features from all designs
-- **Explore alternatives** — Always propose 2-3 approaches before settling
+- **Explore alternatives** — Always propose 2–3 approaches before settling
 - **Incremental validation** — Present design, get approval before moving on
 - **Be flexible** — Go back and clarify when something doesn't make sense
 

--- a/skills/plan-tasks/SKILL.md
+++ b/skills/plan-tasks/SKILL.md
@@ -76,7 +76,7 @@ For small changes, a single task is fine. Don't manufacture fake granularity.
 
 ### Confirm with the User Before Writing
 
-**Do not write any task files yet.** Present the user with a brief overview of your planned breakdown, then use the appropriate tool for asking the user a question or requesting input to get confirmation:
+**Do not write any task files yet.** Present the user with a brief overview of your planned breakdown, then follow the `codagent:ask-questions` skill to get confirmation:
 
 1. State the number of tasks.
 2. For each task, give the title and a 1-sentence summary of its scope — what it delivers, not implementation details.

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -23,14 +23,12 @@ Evaluate whether an idea is worth formalizing, and if so, write the proposal doc
 
 ### 1. Understand
 
-First understand the idea. If the user's invocation didn't include enough context, use the appropriate tool for asking the user a question or requesting input to ask:
+First understand the idea. If the user's invocation didn't include enough context, follow the `codagent:ask-questions` skill to gather:
 - What is the idea? What does it do from the user's perspective?
 - What problem does it solve? Who has this problem?
 - What triggered this? (bug report, user request, personal itch, competitive pressure)
 
-Get clarity on the idea. Ask one or two questions at a time — don't barrage. Prefer multiple-choice questions when possible, but open-ended is fine too. Focus on purpose, constraints, and success criteria. Always use the appropriate tool for asking the user a question or requesting input when you need a response.
-
-Do not proceed until you have a concrete understanding of the idea.
+Focus on purpose, constraints, and success criteria. Do not proceed until you have a concrete understanding of the idea.
 
 ### 2. Research
 
@@ -111,7 +109,7 @@ The proposal should be anchored in the "why" — the problem, the motivation, an
 - **Do not skip the evaluation** — Even for "obvious" ideas, the evaluation surfaces risks and shapes scope. Speed through it, but don't skip it.
 - **Do not cheerlead** — Honest assessment over enthusiasm. Every idea has trade-offs; name them.
 - **Do not go deep on implementation** — The proposal answers "why" and scopes "what". The "how" belongs entirely in design.md. Resist the urge to solve the problem in the proposal.
-- **Do not auto-transition** — Use the appropriate tool for asking the user a question or requesting input to confirm before writing the proposal. A "no-go" verdict means no proposal.
+- **Do not auto-transition** — Follow `codagent:ask-questions` to confirm before writing the proposal. A "no-go" verdict means no proposal.
 - **Do visualize** — Diagrams help clarify thinking. Use them for architecture, comparisons, and flows.
 - **Follow the template** — Use the Artifact Template section below for proposal structure.
 

--- a/skills/review-assumptions/SKILL.md
+++ b/skills/review-assumptions/SKILL.md
@@ -43,7 +43,7 @@ If a finding makes a claim about code ("I fixed X", "already handles Y"), have a
 If you're guessing, it's ambiguous. Calibrate your confidence bar honestly.
 
 <HARD-GATE>
-For ambiguous findings, ask **one question at a time** via the appropriate tool for requesting user input. Never batch. Finish one finding fully — including applying the user's answer — before raising the next.
+For ambiguous findings, ask **one question at a time** via the `codagent:ask-questions` skill. This skill intentionally overrides the default batching strategy: each finding must be fully resolved (including applying the user's answer) before raising the next.
 </HARD-GATE>
 
 Each clarifying question should:

--- a/skills/simple-plan/SKILL.md
+++ b/skills/simple-plan/SKILL.md
@@ -12,6 +12,8 @@ description: >
 
 Rapid, lightweight planning for small changes. One conversation produces a `proposal.md`, one or more spec files, an optional `design.md`, and a `tasks.md` placeholder so the change slots into the OpenSpec workflow.
 
+> **Key principle — write for a different agent.**  The artifacts you produce will be handed to a *separate* implementing agent that has **zero shared context** from this conversation. Every decision, rationale, constraint, file path, naming convention, and behavioral detail must be captured in the written artifacts. If you discussed it but didn't write it down, the implementer won't know about it.
+
 ## Flow
 
 1. **Understand** — Ask the user what the change is about (problem, desired behavior, scope) when not already explicit.
@@ -23,7 +25,11 @@ Rapid, lightweight planning for small changes. One conversation produces a `prop
    - Behaviors, boundaries, and error/edge cases (for the specs — this is the load-bearing part)
    - Scope boundaries (what's in, what's out)
    - Any architectural question that would actually change the specs — otherwise skip it
-4. **Decide if a design doc is needed** — Default: **no**. Only write `design.md` when there's a real architectural choice whose rationale needs to survive (e.g., a non-obvious trade-off future contributors would re-litigate). A small code change, a config tweak, a straightforward CRUD addition, or anything where "the code is the design" does not need one. When unsure, skip it.
+4. **Decide if a design doc is needed** — Default: **no**. Write `design.md` when:
+   - There's a real architectural choice whose rationale needs to survive (e.g., a non-obvious trade-off future contributors would re-litigate), **or**
+   - There are specific implementation details (algorithms, data-structure choices, integration points, migration steps, error-handling strategies, etc.) that came up in conversation but don't belong in behavioral specs. Because a different agent will implement the change, these details **must** be written down somewhere — `design.md` is that somewhere.
+   
+   A small code change, a config tweak, a straightforward CRUD addition, or anything where "the code is the design" does not need one. When in doubt, ask whether the implementer would have enough information without it.
 5. **Confirm the plan** — Briefly restate: capabilities to spec, whether a design doc will be written, and output location. Get a quick thumbs-up before writing.
 6. **Write all the docs in one pass** — `proposal.md`, one `specs/<capability>/spec.md` per capability, optionally `design.md`, and `tasks.md`.
 
@@ -45,7 +51,9 @@ The proposal and (optional) design exist to scaffold the specs. The specs are wh
 
 ## tasks.md
 
-Write a placeholder `tasks.md` — no actual task breakdown. This skill produces one-shot, self-contained plans; the implementer reads the files directly.
+Write a placeholder `tasks.md` — no actual task breakdown. This skill produces one-shot, self-contained plans; a **different agent** reads the files directly to implement the change.
+
+Because the implementer has no context beyond these artifacts, the task entry must link to **every** artifact and the artifacts themselves must be fully self-contained. Before writing `tasks.md`, review your artifacts as a whole: if you realize there are discussed details missing from the specs and design, go back and add them now.
 
 Format:
 

--- a/skills/simple-plan/SKILL.md
+++ b/skills/simple-plan/SKILL.md
@@ -19,7 +19,7 @@ Rapid, lightweight planning for small changes. One conversation produces a `prop
    - **Related existing specs** — scan spec files in neighboring or overlapping capabilities for conflicts, dependencies, and naming conventions. For modified capabilities, locate the existing spec now.
    - **Code, when appropriate** — if the change touches existing code, skim the relevant files/modules to understand current behavior. Skip this for greenfield work, pure doc changes, or anything where reading code wouldn't change what you ask.
    Keep it light — this is a quick orientation, not the deep research pass from `propose` or `design`.
-3. **Clarify** — Ask clarifying questions **one at a time**. Prefer multiple-choice when it fits. Keep the conversation tight — a handful of questions, not a full interview. Focus on:
+3. **Clarify** — Follow the `codagent:ask-questions` skill to gather information. Keep the conversation tight — a handful of questions total, not a full interview. Focus on:
    - Behaviors, boundaries, and error/edge cases (for the specs — this is the load-bearing part)
    - Scope boundaries (what's in, what's out)
    - Any architectural question that would actually change the specs — otherwise skip it
@@ -64,7 +64,7 @@ Use relative paths from the change directory. Include every spec file. Include `
 - **Do NOT cheerlead.** If you spot a real problem with the idea, say so — but don't run a full GO/NO-GO evaluation.
 - **Do NOT pad with unused sections.** Omit sections of the templates that don't apply.
 - **Do NOT write `design.md` by default.** The bar is "someone will re-litigate this later without a written rationale." If that's not true, skip it.
-- **Do ask one question at a time.** The only process discipline that matters here.
+- **Follow `codagent:ask-questions`.** For tool choice and batching strategy whenever you need user input.
 
 ---
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -68,11 +68,9 @@ digraph spec {
 - Work through capabilities one at a time
 
 **Asking clarifying questions:**
-- Use the appropriate tool for asking the user a question or requesting input for all questions and confirmations
-- Ask questions one at a time to understand the behavioral contract for each capability
-- Prefer multiple-choice questions when possible, but open-ended is fine too
-- Only one question per message — if a topic needs more exploration, break it into multiple questions
+- Follow the `codagent:ask-questions` skill for how to ask questions (tool to use, batching strategy, question quality)
 - Focus on: what the system does (behaviors), what it rejects (boundaries), what goes wrong (error conditions), unusual situations (edge cases)
+- Prefer multiple-choice questions when possible, but open-ended is fine too
 - Do NOT ask about architecture, patterns, or technical approach — that belongs in design
 
 **When a requirement depends on architectural knowledge:**
@@ -102,7 +100,7 @@ Tell the user the relative path of each spec file created. This skill does not i
 
 ## Key Principles
 
-- **One question at a time** — Don't overwhelm with multiple questions
+- **Use `codagent:ask-questions`** — For tool choice and batching strategy when gathering information
 - **Multiple choice preferred** — Easier to answer than open-ended when possible
 - **Focus on "what", not "how"** — Behaviors, boundaries, and error conditions — not architecture
 - **Deferred is valid** — A deferred-to-design marker is better than a forced answer


### PR DESCRIPTION
## Summary

- **ask-questions skill**: Centralized guidance for how to ask users questions interactively — which tool to use, how to batch questions, and when to ask serially. Other question-asking skills now invoke this skill instead of duplicating the pattern.
- **handoff skill**: Summarizes a specific aspect of a conversation so another agent can resume with full context.
- **review-assumptions skill**: Audits implementor session reports for risky assumptions and context gaps, fixes high-confidence issues directly, and asks one clarifying question at a time for ambiguous findings.
- **session-report update**: Drops benign assumptions from output to reduce noise.
- **Skill frontmatter cleanup**: Removed `name` fields from skill frontmatter (they override display prefixes) and added a CLAUDE.md note documenting this convention.
- **Design & simple-plan skills**: Added "write for a different agent" guidance so generated task descriptions are self-contained for subagent consumption.
- **Updated question-asking skills** (propose, spec, design, simple-plan, plan-tasks) to invoke `codagent:ask-questions` instead of inline instructions.

## Commits

- `e409018` add handoff skill for summarizing conversation context
- `2126acf` add review-assumptions skill for auditing implementation decisions
- `0f24228` update session-report to drop benign assumptions from output
- `38bb705` fix skill frontmatter: add name fields and third-person descriptions
- `b884dac` remove name field from skill frontmatter, add CLAUDE.md note
- `269745b` add ask-questions skill, update all question-asking skills to invoke it
- `b27c57a` Add 'write for a different agent' guidance to simple-plan and design skills

## Test plan

- [ ] Verify `codagent:ask-questions` skill triggers correctly when invoked by other skills
- [ ] Verify `codagent:handoff` produces useful summaries for agent-to-agent handoff
- [ ] Verify `codagent:review-assumptions` correctly parses session report output
- [ ] Confirm no skill displays incorrect prefix names after frontmatter cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)