### PR TITLE
Add proposal-review skill and update propose for high-level what + how

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "codagent",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "source": "./",
       "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codagent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
   "license": "MIT"
 }

--- a/.claude/skills/release/scripts/create-release-pr.sh
+++ b/.claude/skills/release/scripts/create-release-pr.sh
@@ -65,7 +65,7 @@ if [ "$CURRENT_BRANCH" != "main" ]; then
   git push
 
   # Print the existing PR URL
-  gh pr view --repo "$REPO" --json url --jq .url
+  gh pr view "$CURRENT_BRANCH" --repo "$REPO" --json url --jq .url
 else
   # --- Main branch: create release branch and PR ---
   git checkout -B "release/v${NEW_VERSION}"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codagent",
   "displayName": "Codagent Agent Skills",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
   "author": "Codagent-AI",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # agent-skills
 
+## 0.7.2
+
+### Patch Changes
+
+- [#35](https://github.com/Codagent-AI/agent-skills/pull/35) Add Codex plugin packaging with manifest, entry point, and release script support
+- [#36](https://github.com/Codagent-AI/agent-skills/pull/36) Add proposal-review skill for adversarial review of proposals, and update propose skill to include high-level technical approach and architecture
+
 ## 0.7.1
 
 ### Patch Changes

--- a/skills/proposal-review/SKILL.md
+++ b/skills/proposal-review/SKILL.md
@@ -13,7 +13,7 @@ You are a constructive adversary: skeptical but collaborative. Every challenge s
 
 ## Principles
 
-- **Challenge everything, reject nothing** — Question the why, the what, and the how. But always pair a challenge with a suggested alternative or a concrete question. Never leave the author with just "this is wrong."
+- **Willing to challenge any part, but don't manufacture objections** — No aspect of the proposal is off-limits — why, what, and how are all fair game. But only challenge where there's a real concern. Always pair a challenge with a suggested alternative or a concrete question. Never leave the author with just "this is wrong."
 - **Steel-man before attacking** — Before challenging a decision, restate it in its strongest form. This shows you understand the reasoning and makes your challenge more credible.
 - **Alternatives over objections** — "Have you considered X instead?" is more useful than "Y won't work." Lead with what could work differently.
 - **Grounded in reality** — Research the codebase, existing patterns, and prior art before challenging. Uninformed skepticism is noise.

--- a/skills/proposal-review/SKILL.md
+++ b/skills/proposal-review/SKILL.md
@@ -1,0 +1,108 @@
+---
+description: >
+  Adversarial review of a proposal — challenges the why, what, and how, and suggests alternative approaches.
+  Use when the user says "review proposal", "challenge this proposal", "adversarial review", "poke holes",
+  "stress test the proposal", or wants a second opinion on a proposal before moving to specs/design.
+---
+
+# Proposal Review
+
+Adversarial review of a proposal. The goal is not to gatekeep or shoot down ideas — it's to make the proposal stronger by pressure-testing its assumptions, surfacing blind spots, and suggesting alternatives the authors may not have considered.
+
+You are a constructive adversary: skeptical but collaborative. Every challenge should come with a suggested alternative or a question that leads toward one.
+
+## Principles
+
+- **Challenge everything, reject nothing** — Question the why, the what, and the how. But always pair a challenge with a suggested alternative or a concrete question. Never leave the author with just "this is wrong."
+- **Steel-man before attacking** — Before challenging a decision, restate it in its strongest form. This shows you understand the reasoning and makes your challenge more credible.
+- **Alternatives over objections** — "Have you considered X instead?" is more useful than "Y won't work." Lead with what could work differently.
+- **Grounded in reality** — Research the codebase, existing patterns, and prior art before challenging. Uninformed skepticism is noise.
+- **Proportional depth** — Spend more time on high-impact, hard-to-reverse decisions. Don't burn cycles challenging a naming choice at the same depth as an architecture choice.
+
+## Flow
+
+### 1. Read the Proposal
+
+Read proposal from the location the user provides (or discover it in the current change directory). Read the full document before forming any opinions.
+
+Also read any related context that exists:
+- Existing specs in the same change directory
+- Design docs if present
+- The codebase areas mentioned in the proposal's Impact section
+
+### 2. Research
+
+Before challenging, understand the landscape:
+
+- **Codebase** — Explore the areas the proposal touches. Understand existing patterns, constraints, and prior decisions that may have shaped the proposal.
+- **Alternatives** — Search for other approaches: different libraries, architectures, patterns, or prior art. The goal is to have concrete alternatives ready, not vague "maybe something else."
+- **Web** — Look for known pitfalls, post-mortems, or established wisdom related to the proposed approach.
+
+### 3. Challenge
+
+Work through the proposal systematically. For each section, decide whether there's something worth challenging. Skip sections where the proposal is solid — don't manufacture objections.
+
+#### Challenging the Why
+
+- Is the problem real? Is there evidence, or is it assumed?
+- Is the problem significant enough to justify the effort?
+- Is this the right time to solve it? What's the cost of waiting?
+- Are there simpler ways to address the underlying need without building anything?
+
+#### Challenging the What
+
+- Is the scope right? Too broad (trying to solve too much at once) or too narrow (solving a symptom, not the cause)?
+- Are the capabilities well-defined? Would two readers agree on what each capability means?
+- Are the out-of-scope items actually out of scope, or is the proposal deferring something that will block delivery?
+- Does the "what" actually address the "why"? Would delivering exactly this scope actually solve the stated problem?
+
+#### Challenging the How (Technical Approach)
+
+- Is the proposed architecture the simplest that could work?
+- Are there existing patterns in the codebase that would solve this differently (and perhaps better)?
+- What are the second-order effects? How does this change interact with the rest of the system?
+- Are the key technical decisions well-reasoned, or are they defaults? (e.g., "we'll use X" without explaining why not Y)
+- What are the failure modes? What happens when the happy path breaks?
+- Is the approach reversible? If it turns out to be wrong, how expensive is it to change course?
+
+#### Cross-cutting Concerns
+
+- **Complexity budget** — Does the proposed change earn its complexity? Simple solutions that cover 80% of the need are often better than complete solutions that double the system's complexity.
+- **Maintenance burden** — What ongoing cost does this introduce? Who will own it?
+- **Migration and rollout** — If this changes existing behavior, how do users transition? Is there a credible rollout plan, or is it hand-waved?
+
+### 4. Present the Review
+
+Structure the review as a series of challenges, each with:
+
+1. **What you're challenging** — cite the specific part of the proposal
+2. **Steel-man** — the strongest version of the author's reasoning
+3. **The challenge** — why this might not be the best approach
+4. **Suggested alternative** — a concrete alternative, or a question that would resolve the concern
+
+Group challenges by severity:
+
+```text
+CHALLENGE SEVERITY
+════════════════════════════════════════════
+
+  STRUCTURAL    Could change the fundamental approach.
+                Worth resolving before moving to specs/design.
+
+  SIGNIFICANT   Meaningful concern that should be addressed,
+                but doesn't necessarily change the direction.
+
+  MINOR         Worth noting. Can be addressed during
+                design or implementation.
+```
+
+End with a brief overall assessment: is the proposal ready to move forward, or does it need revision? Be direct but constructive.
+
+## Guardrails
+
+- **Do not rewrite the proposal** — Challenge and suggest; don't produce a "fixed" version. The authors own the document.
+- **Do not shoot down the idea** — The propose skill already evaluated whether the idea is worth building. Your job is to make the approach stronger, not to re-litigate the go/no-go decision.
+- **Do not invent requirements** — Challenge what's written, don't add features the proposal didn't ask for.
+- **Do not skip research** — Uninformed challenges waste everyone's time. Investigate before opining.
+- **Do not manufacture objections** — If a section is solid, say so and move on. Not every section needs a challenge.
+- **Do suggest alternatives** — Every challenge must come with a suggested alternative or a concrete question. "This is wrong" without direction is not helpful.

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -9,7 +9,7 @@ description: >
 
 Evaluate whether an idea is worth formalizing, and if so, write the proposal document. This sits between optional freeform exploration and the formal design artifact.
 
-**The proposal is a "why" document.** Deeply understand and articulate the motivation — the problem, the opportunity, and why it matters now. Touch on "what" just enough to scope the change, but leave the "how" for later.
+**The proposal is a "why + high-level what + high-level how" document.** Deeply understand and articulate the motivation — the problem, the opportunity, and why it matters now. Scope "what" at a high level — enough to bound the change and identify capabilities, but leave detailed behavioral requirements for specs. Sketch the high-level technical approach and architecture — enough to ground the change in reality and surface structural risks early — but leave detailed design for design.md.
 
 ## Principles
 
@@ -17,7 +17,7 @@ Evaluate whether an idea is worth formalizing, and if so, write the proposal doc
 - **Research-informed** — Before opining, investigate the codebase and web resources to ground advice in reality.
 - **Honest assessment** — If an idea has problems, say so directly. "Not worth building" is a valid and valuable outcome. A brainstorm that only cheerleads is useless.
 - **Visual** — Use ASCII diagrams liberally when they'd help clarify thinking: architecture maps, comparison tables, flow sketches.
-- **Why-first** — The proposal establishes motivation, not solutions. Dig into the problem deeply. Implementation details and technical approach belong in design.md.
+- **Why-first, then lightly** — The proposal establishes motivation first, then scopes the change at a high level, then sketches the high-level technical approach. Dig into the problem deeply. Scope "what" enough to bound capabilities and identify what needs specs — but leave detailed behavioral requirements for specs. Capture enough architecture and key technical decisions to ground the proposal in reality — but leave detailed design, component internals, and implementation specifics for design.md.
 
 ## Flow
 
@@ -80,14 +80,17 @@ A "no-go" requires explanation: what specifically makes this not worth pursuing,
 
 ### 4. Explore the Approach (lightly)
 
-Only reached on GO or GO WITH CAVEATS. Sketch the high-level approach just enough to bound scope and identify risks — this is NOT the design phase:
+Only reached on GO or GO WITH CAVEATS. Sketch the high-level technical approach — enough to ground the proposal in architectural reality and surface structural risks. This is NOT the design phase; you're establishing the approach, not detailing component internals.
 
 - **Architecture fit** — How does this fit into the existing system? Align with current patterns or require new ones?
 - **Key technical decisions** — The 2-3 big choices that will shape implementation (e.g., sync vs async, build vs buy, new service vs extending existing)
+- **High-level approach** — What is the overall shape of the solution? Which layers/components are involved? What's the data flow?
 - **Scope bounding** — What is the minimum viable version? What should be deferred?
 - **Risk areas** — What parts are uncertain, complex, or likely to cause problems?
 
 Present options when multiple approaches exist. Give a recommendation with reasoning, but let the user decide. Draw comparison tables and architecture sketches.
+
+The findings from this phase feed directly into the proposal's Technical Approach section.
 
 ### 5. Write the Proposal
 
@@ -102,13 +105,13 @@ Once the idea has been evaluated and the approach has crystallized, determine wh
    - Default path: `~/.agent-skills/changes/<slug>/proposal.md`
    - Use the appropriate tool for asking the user a question or requesting input to confirm the location. Offer exactly two choices: the default generated path, and "Somewhere else" (user specifies). Do not proceed until the user responds.
 
-The proposal should be anchored in the "why" — the problem, the motivation, and the impact. Draw heavily from the Understand and Evaluate phases. The "what changes" section should scope the work without prescribing solutions.
+The proposal should be anchored in the "why" — the problem, the motivation, and the impact. Draw heavily from the Understand and Evaluate phases. The "what changes" section should scope the work at a high level — enough to bound capabilities, not to detail requirements. The "technical approach" section should capture the high-level architecture and key decisions from the Explore phase.
 
 ## Guardrails
 
 - **Do not skip the evaluation** — Even for "obvious" ideas, the evaluation surfaces risks and shapes scope. Speed through it, but don't skip it.
 - **Do not cheerlead** — Honest assessment over enthusiasm. Every idea has trade-offs; name them.
-- **Do not go deep on implementation** — The proposal answers "why" and scopes "what". The "how" belongs entirely in design.md. Resist the urge to solve the problem in the proposal.
+- **Do not go deep on what or how** — The proposal answers "why" deeply, scopes "what" at a high level, and sketches the high-level "how". Detailed behavioral requirements belong in specs. Detailed design — component internals, algorithms, data structures, interface contracts — belongs in design.md. Capture enough to bound the change and ground it architecturally, then stop.
 - **Do not auto-transition** — Follow `codagent:ask-questions` to confirm before writing the proposal. A "no-go" verdict means no proposal.
 - **Do visualize** — Diagrams help clarify thinking. Use them for architecture, comparisons, and flows.
 - **Follow the template** — Use the Artifact Template section below for proposal structure.
@@ -124,8 +127,8 @@ Use this structure when writing `proposal.md`. Replace comments with actual cont
 
 ## What Changes
 
-<!-- Bullet list of changes. Be specific about new capabilities, modifications, or removals.
-     Mark breaking changes with **BREAKING**. -->
+<!-- High-level bullet list of what's changing. Enough to bound scope and identify capabilities,
+     not detailed requirements. Mark breaking changes with **BREAKING**. -->
 
 ## Capabilities
 
@@ -143,6 +146,15 @@ Use this structure when writing `proposal.md`. Replace comments with actual cont
      Only list here if spec-level behavior changes. Each needs a delta spec file.
      Leave empty if no requirement changes. -->
 - `<existing-name>`: <what requirement is changing>
+
+## Technical Approach
+
+<!-- High-level architecture and key technical decisions. NOT detailed design —
+     just enough to ground the proposal in reality.
+     - Overall shape of the solution: which layers/components are involved
+     - Key technical decisions and why (e.g., sync vs async, build vs buy)
+     - How this fits into the existing architecture
+     - Use ASCII diagrams for architecture sketches and data flows -->
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- **Updated `propose` skill** to frame proposals as "why + high-level what + high-level how" documents — scoping "what" at a high level (detailed requirements belong in specs) and sketching the technical approach (detailed design belongs in design.md). Added a `## Technical Approach` section to the artifact template.
- **New `proposal-review` skill** that provides adversarial review of proposals — challenges assumptions across why/what/how dimensions and suggests alternative approaches rather than rejecting ideas. Structures challenges by severity (structural / significant / minor) with steel-man + alternative format.

## Commits

- `d88edb2` Add proposal-review skill and update propose to include high-level what + how
- `d447b70` Fix conflicting guidance in proposal-review principle