### PR TITLE
Add skill names for Vercel compatibility

### DIFF
--- a/skills/ask-questions/SKILL.md
+++ b/skills/ask-questions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ask-questions
 description: >
   How to ask users questions interactively: which tool to use, how to batch questions, and
   when to ask serially. Follow this skill when asking clarifying questions, requesting

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: design
 description: >
   Creates design artifacts through collaborative brainstorming of approaches, architecture, and trade-offs.
   Use when the user says "design this", "create a design", "brainstorm approaches", or "write a design doc".

--- a/skills/finalize-pr/SKILL.md
+++ b/skills/finalize-pr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: finalize-pr
 description: >
   Orchestrates the full post-implementation loop: push PR → wait for CI → fix failures → repeat
   until CI passes or termination rules trigger a pause.

--- a/skills/fix-pr/SKILL.md
+++ b/skills/fix-pr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: fix-pr
 description: >
   Fixes CI failures and review comments on the current branch's pull request by dispatching
   a fixer subagent, verifying with the validator, and pushing the fix. Use when the user says

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: handoff
 description: >
   Summarizes a specific aspect of the current conversation so another agent can resume.
   Use when the user says "handoff", "summarize for handoff", "write a handoff", or wants to

--- a/skills/implement-and-validate/SKILL.md
+++ b/skills/implement-and-validate/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: implement-and-validate
 description: >
   Autonomous implementer agent that executes a single task end-to-end using TDD and verifies with Agent Validator.
   Activates for requests such as "implement this task", "finish this ticket", "apply this spec end-to-end", or "complete the implementation".

--- a/skills/implement-change/SKILL.md
+++ b/skills/implement-change/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: implement-change
 description: >
   Autonomous tech lead that implements a full change end-to-end by dispatching one subagent per task
   sequentially using implement-and-validate, running the validator, and finalizing the PR. Activates

--- a/skills/implement-with-tdd/SKILL.md
+++ b/skills/implement-with-tdd/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: implement-with-tdd
 description: >
   Enforces test-driven development for feature work, bug fixes, and refactoring, activating for requests
   such as "implement", "fix", "add feature", "write tests first", or "TDD".

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: init
 description: >
   Initializes Agent Skills in a project by checking prerequisites and verifying the validator
   configuration. Use when the user says "init", "set up agent-skills", or "initialize agent-skills".

--- a/skills/plan-tasks/SKILL.md
+++ b/skills/plan-tasks/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: plan-tasks
 description: Creates a structured implementation task breakdown for a structured change, synthesizing proposal, design, and specs into self-contained per-task files. Use when the tasks artifact is the next step in a change.
 ---
 

--- a/skills/proposal-review/SKILL.md
+++ b/skills/proposal-review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: proposal-review
 description: >
   Adversarial review of a proposal — challenges the why, what, and how, and suggests alternative approaches.
   Use when the user says "review proposal", "challenge this proposal", "adversarial review", "poke holes",

--- a/skills/propose/SKILL.md
+++ b/skills/propose/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: propose
 description: >
   Evaluate whether a software idea is worth building, then write the proposal document.
   Use when the user wants to assess an idea, says "evaluate", "propose", "is this worth building",

--- a/skills/push-pr/SKILL.md
+++ b/skills/push-pr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: push-pr
 description: >
   Commits changes, pushes to remote, and creates or updates a pull request for the current branch.
   Use when the user says "push pr", "create pr", "push and create pr", or invokes "codagent:push-pr".

--- a/skills/review-assumptions/SKILL.md
+++ b/skills/review-assumptions/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review-assumptions
 description: >
   Reviews risky/notable assumptions and context gaps surfaced by implementor session reports,
   fixes high-confidence issues directly, and asks one clarifying question at a time for

--- a/skills/review-spec/SKILL.md
+++ b/skills/review-spec/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review-spec
 description: >
   Reviews design artifacts (proposal, specs, design, tasks) for internal consistency, gaps, and cross-artifact alignment.
   Use when the user says "review spec", "review artifacts", "review the design docs", "review the change",

--- a/skills/session-report/SKILL.md
+++ b/skills/session-report/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: session-report
 description: >
   Audits your session for assumptions and context gaps — things only a human can act on.
   Use when the user says "session report", "review assumptions", "what did you struggle with",

--- a/skills/simple-plan/SKILL.md
+++ b/skills/simple-plan/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: simple-plan
 description: >
   Lightweight planning for small, quick changes. Combines propose, spec, and (optionally) design
   into one conversational pass, then writes tasks.md so the change is ready for OpenSpec

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: spec
 description: >
   Drives interactive requirement discovery to produce spec files.
   Use when the user says "spec this", "write specs", "create specs", or "run the spec skill".

--- a/skills/task-compliance/SKILL.md
+++ b/skills/task-compliance/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: task-compliance
 description: >
   Review an implementation against task file requirements. Checks every spec scenario and Done When criterion,
   identifies gaps, and reports them.

--- a/skills/wait-ci/SKILL.md
+++ b/skills/wait-ci/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: wait-ci
 description: >
   Polls CI check status for the current branch's pull request and reports pass/fail/pending/comments,
   surfacing PR review comments even when CI is green.


### PR DESCRIPTION
## Summary
- add name frontmatter to top-level skills
- keep existing descriptions and content unchanged
- enables Vercel skills CLI discovery for Codagent-AI/agent-skills

## Verification
- npx --yes skills add . --list