### PR TITLE
feat: add prepare acceptance skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "codagent",
-      "version": "0.7.6",
+      "version": "0.8.0",
       "source": "./",
       "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codagent",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
   "license": "MIT"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codagent",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "A curated set of skills for each stage of development - propose, spec, design, plan, implement, ship.",
   "author": {
     "name": "Codagent-AI",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codagent",
   "displayName": "Codagent Agent Skills",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "A curated set of skills for each stage of development — propose, spec, design, plan, implement, ship.",
   "author": "Codagent-AI",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # agent-skills
 
+## 0.8.0
+
+### Minor Changes
+
+- [#44](https://github.com/Codagent-AI/agent-skills/pull/44) Add reusable human-style acceptance testing, revision-bound review evidence, and caller-owned correction and control-flow integration.
+
 ## 0.7.6
 
 ### Patch Changes

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,7 +17,7 @@ The core skills cover four parts of the development lifecycle:
 
 - Planning: `propose`, `proposal-review`, `spec`, `design`, `plan-tasks`, `review-spec`, and `simple-plan`
 - Implementation: `implement-with-tdd`, `implement-and-validate`, and `implement-change`
-- Pull requests: `push-pr`, `wait-ci`, `fix-pr`, and `finalize-pr`
+- Pull requests: `push-pr`, `wait-ci`, `prepare-acceptance`, `fix-pr`, and `finalize-pr`
 - Support and review: `init`, `ask-questions`, `handoff`, `session-report`, `review-assumptions`, and `task-compliance`
 
 The repository also includes a separate release skill under `.agents/skills/release` and `.claude/skills/release`. That release skill is for maintainers of this repository, not part of the installed user-facing Codagent workflow.

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -67,6 +67,10 @@ Commits local changes, pushes the branch, and creates or updates the current bra
 
 Polls CI for the current branch PR. It reports pass, fail, pending, or comments status; fetches failed GitHub Actions logs; checks blocking reviews; and surfaces unresolved PR comments.
 
+### `prepare-acceptance`
+
+Prepares a draft PR for human acceptance. It exercises every supported user or client flow through the real product surface, reports clear defects to the caller, captures screenshots for every UI flow or client-style evidence for non-UI flows, waits for current-head CI once stable, and writes revision-bound acceptance-test and handoff artifacts. Fixes and automated validation are handled by the caller.
+
 ### `fix-pr`
 
 Fixes CI failures and review comments for the current branch PR. It gathers failure context, dispatches a fixer subagent, verifies the fix with Agent Validator, pushes, and resolves addressed review threads when possible.

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -69,7 +69,7 @@ Polls CI for the current branch PR. It reports pass, fail, pending, or comments 
 
 ### `prepare-acceptance`
 
-Prepares a draft PR for human acceptance. It exercises every supported user or client flow through the real product surface, reports clear defects to the caller, captures screenshots for every UI flow or client-style evidence for non-UI flows, waits for current-head CI once stable, and writes revision-bound acceptance-test and handoff artifacts. Fixes and automated validation are handled by the caller.
+Prepares an implemented PR revision for human acceptance. It exercises every supported user or client flow through the real product surface, reports clear defects to the caller, captures screenshots for every UI flow or client-style evidence for non-UI flows, waits for current-head CI once stable, and writes revision-bound acceptance-test and handoff artifacts. Fixes and any automated validation are handled by the caller; the skill records their evidence or absence and the current PR state without changing it.
 
 ### `fix-pr`
 

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -59,7 +59,7 @@ Tasks are ordered so dependent work stays sequential.
 
 `wait-ci` polls the current branch PR, reports CI status, gathers failed GitHub Actions logs, checks blocking reviews, and surfaces unresolved PR comments.
 
-`prepare-acceptance` supports workflows that separate autonomous implementation from human acceptance. Starting from a draft PR, it exercises every supported user or client flow through the real product surface, captures screenshots for UI flows or client-style evidence for APIs and CLIs, reports clear defects to the caller, waits for CI on a stable tested head, and produces a concise evidence package for the human review session. Fixes and automated validation remain the caller's responsibility.
+`prepare-acceptance` supports workflows that separate autonomous implementation from human acceptance. Starting from an implemented PR revision, it exercises every supported user or client flow through the real product surface, captures screenshots for UI flows or client-style evidence for APIs and CLIs, reports clear defects to the caller, waits for CI on a stable tested head, and produces a concise evidence package for the human review session. Fixes and any automated validation remain the caller's responsibility; the skill records their evidence or absence and the current PR state without changing it.
 
 `fix-pr` addresses CI failures and review comments by dispatching a fixer subagent, verifying the fix, and pushing.
 

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -59,6 +59,8 @@ Tasks are ordered so dependent work stays sequential.
 
 `wait-ci` polls the current branch PR, reports CI status, gathers failed GitHub Actions logs, checks blocking reviews, and surfaces unresolved PR comments.
 
+`prepare-acceptance` supports workflows that separate autonomous implementation from human acceptance. Starting from a draft PR, it exercises every supported user or client flow through the real product surface, captures screenshots for UI flows or client-style evidence for APIs and CLIs, reports clear defects to the caller, waits for CI on a stable tested head, and produces a concise evidence package for the human review session. Fixes and automated validation remain the caller's responsibility.
+
 `fix-pr` addresses CI failures and review comments by dispatching a fixer subagent, verifying the fix, and pushing.
 
 `finalize-pr` orchestrates the full loop: push PR, wait for CI, fix failures or comments, and repeat until the PR is green or the documented termination rules require a pause.

--- a/skills/prepare-acceptance/SKILL.md
+++ b/skills/prepare-acceptance/SKILL.md
@@ -1,19 +1,15 @@
 ---
-description: >
-  Exercises an implemented change through its user and client flows, reports clear defects to a
-  caller without fixing them, waits for current-head CI once stable, and prepares concise evidence for
-  human review. Use when preparing a change for acceptance, gathering review evidence, performing
-  human-style flow testing, or when invoked as codagent:prepare-acceptance.
+description: Exercises an implemented change through its user and client flows, reports clear defects without fixing them, waits for current-head CI, and prepares concise evidence for human review when preparing a change for acceptance, gathering review evidence, performing human-style flow testing, or invoking codagent:prepare-acceptance.
 ---
 
-# Prepare Acceptance
+## Prepare Acceptance
 
 Prepare an implemented change for a separate human acceptance session. Exercise it as a human user or
 real client would, report clear defects, wait for CI once no defects remain, and produce concise
 evidence bound to the exact PR revision. Fixes and automated validation belong to separate
 caller-managed steps when used.
 
-## Required inputs
+### Required inputs
 
 Resolve these from the caller before acting:
 
@@ -28,18 +24,19 @@ product behavior from implementation alone. When no assumptions-ledger path is s
 autonomous: preserve product, scope, or design ambiguity for the later human acceptance session
 instead of asking the user here.
 
-## Procedure
+### Procedure
 
-### 1. Pin the tested revision
+#### 1. Pin the tested revision
 
 1. Read repository instructions, the approved artifacts, the unresolved-assumptions ledger, and the
    existing automated-validation evidence supplied by the caller.
-2. Record local `HEAD`. Read only the PR URL, current head SHA, and current PR state needed for the
-   evidence record. Do not inspect or reconstruct a diff.
+2. Record local `HEAD` as the tested SHA and preserve it through the flow pass and CI wait. Read only
+   the PR URL, current head SHA, and current PR state needed for the evidence record. Do not inspect or
+   reconstruct a diff.
 3. Require a clean tracked worktree and local `HEAD` equal to the PR head. If they do not match, stop
    for the caller to resolve; do not push or alter PR metadata in this skill.
 
-### 2. Exercise the product like a user
+#### 2. Exercise the product like a user
 
 Derive a concise list of supported user or client flows only from the approved artifacts and the
 caller-supplied implementation evidence. Do not inspect a diff to discover behavior. Exercise every
@@ -69,12 +66,12 @@ behavior, concise reproduction steps, and evidence paths. Do not wait for CI or 
 evidence in that invocation. Report the findings clearly so the caller can run its fix and validation
 process.
 
-Append product, scope, or design ambiguity to the resolved assumptions ledger with the decision needed
-and likely impact; never silently choose an interpretation or report ambiguity as a clear defect. Every
-invocation re-exercises all supported flows against the current committed `HEAD`; never reuse results
-or screenshots from an earlier invocation.
+Append product, scope, or design ambiguity to the unresolved-assumptions ledger with the decision
+needed and likely impact; never silently choose an interpretation or report ambiguity as a clear
+defect. Every invocation re-exercises all supported flows against the current committed `HEAD`; never
+reuse results or screenshots from an earlier invocation.
 
-### 3. Capture visual evidence
+#### 3. Capture visual evidence
 
 For any UI—including web, mobile, desktop, and TUI—store screenshots under
 `<evidence-directory>/acceptance-screenshots/` as the flows are exercised. Capture at least one
@@ -93,10 +90,12 @@ Record for every screenshot:
 Screenshots support the observed interaction; they are not proof on their own. For non-visual surfaces,
 retain the corresponding client request/output evidence instead.
 
-### 4. Wait for current-head CI
+#### 4. Wait for current-head CI
 
 Invoke `codagent:wait-ci` after a complete flow pass finds no clear defects and the final tested head is
-pushed. Require its report to apply to the exact local and PR head SHA used for the flow pass.
+pushed. After it returns, immediately re-read local `HEAD` and the PR `headRefOid`. Require the
+preserved tested SHA, returned `head_sha`, current local `HEAD`, and current PR head to be identical;
+otherwise stop and report the evidence as stale before writing acceptance-test or handoff evidence.
 
 - `passed`: continue.
 - `failed` or `comments`: do not write final acceptance-test or handoff evidence or claim readiness.
@@ -112,7 +111,7 @@ pushed. Require its report to apply to the exact local and PR head SHA used for 
 Treat skipped, neutral, cancelled, stale, and timed-out checks as explicit evidence states, never as
 proof that associated behavior passed.
 
-### 5. Write acceptance-test evidence
+#### 5. Write acceptance-test evidence
 
 Write `acceptance-test.md` in the evidence directory only after CI passes or is explicitly absent, the
 complete flow pass makes no tracked changes, and any automated-validation evidence supplied by the
@@ -131,7 +130,7 @@ supplied; explicitly record its absence instead. Include:
 
 Prefer concise conclusions with durable log paths over raw log dumps.
 
-### 6. Prepare the human handoff
+#### 6. Prepare the human handoff
 
 Collate existing implementation, acceptance-test, available automated-validation, and CI evidence. Do
 not run new acceptance tests, capture replacement screenshots, or fix issues during collation. If
@@ -153,7 +152,7 @@ Write `acceptance-handoff.md` in the evidence directory with:
 6. **Residual risk** — unavailable flows, environment limitations, warnings, and relevant omissions.
 7. **Assumption handoff** — canonical ledger path plus a concise summary of every unresolved item.
 
-### 7. Verify readiness
+#### 7. Verify readiness
 
 Before reporting readiness:
 
@@ -169,7 +168,7 @@ Report the exact ready-for-acceptance SHA, PR URL, handoff path, unresolved-deci
 and known limitations. Do not mark the PR ready or perform human acceptance. The caller owns any
 machine-readable status file, terminal marker, or control-flow protocol.
 
-## Out of scope
+### Out of scope
 
 - Do not obtain human acceptance; leave that to the later human acceptance session.
 - Do not fix implementation defects, modify repository files, commit, push, or alter PR metadata.

--- a/skills/prepare-acceptance/SKILL.md
+++ b/skills/prepare-acceptance/SKILL.md
@@ -1,0 +1,184 @@
+---
+description: >
+  Exercises an implemented change through its user and client flows, reports clear defects to a
+  caller-managed fix and validation loop, waits for current-head CI once stable, and prepares concise
+  evidence for human review. Use when preparing a change for acceptance, gathering review evidence,
+  performing human-style flow testing, or when invoked as codagent:prepare-acceptance.
+---
+
+# Prepare Acceptance
+
+Prepare an implemented change for a separate human acceptance session. Exercise it as a human user or
+real client would, report clear defects, wait for CI once no defects remain, and produce concise
+evidence bound to the exact PR revision. Fixes and automated validation belong to separate
+caller-managed steps.
+
+## Required inputs
+
+Resolve these from the caller before acting:
+
+- approved requirements, scenarios, design, and task artifacts;
+- caller-supplied implementation summary or completion evidence identifying delivered behavior;
+- evidence output directory;
+- unresolved-assumptions ledger path, when one exists;
+- required PR state.
+
+Treat missing source-of-truth artifacts or an unspecified evidence directory as blockers. Do not infer
+product behavior from implementation alone. Keep this workflow autonomous: preserve product, scope,
+or design ambiguity for the later human acceptance session instead of asking the user here.
+
+## Procedure
+
+### 1. Pin the tested revision
+
+1. Read repository instructions, the approved artifacts, the unresolved-assumptions ledger, and the
+   existing automated-validation evidence supplied by the caller.
+2. Record local `HEAD`. Read only the PR URL, current head SHA, and draft state needed for acceptance.
+   Do not inspect or reconstruct a diff.
+3. Require a clean tracked worktree, the required PR state, and local `HEAD` equal to the PR head. If
+   they do not match, stop for the caller to resolve; do not push or alter PR metadata in this skill.
+
+### 2. Exercise the product like a user
+
+Derive a concise list of supported user or client flows only from the approved artifacts and the
+caller-supplied implementation evidence. Do not inspect a diff to discover behavior. Exercise every
+flow end to end through the same public surface a real user or client would use. A flow is a meaningful
+journey or operation, not every input permutation.
+
+- For a web, mobile, desktop, or terminal UI, navigate and operate it through its real interface.
+- For an API, call it through its documented HTTP, SDK, or CLI surface as a client would. Record a
+  sanitized request shape, response status and relevant response excerpt, plus observable side effects.
+- For a CLI or library, invoke its public commands or API as a consumer would and retain representative
+  input, output, and resulting state.
+- For background behavior, trigger it through the normal entry point and inspect the user-visible or
+  externally observable result.
+
+Use typical representative data, configuration, and roles. Do not run automated unit, integration, or
+end-to-end suites, linters, builds, or other automated validation commands; those belong to the caller.
+Do not fuzz, try bizarre inputs, attempt to break the product, or build an exhaustive edge-case matrix.
+Test an error, empty, boundary, or transient state only when it is an approved flow or necessary to
+complete a normal flow.
+
+For each flow, record the action, observed outcome, concise evidence, and any limitation. Verify the
+resulting state instead of relying on task completion or agent assertions.
+
+When a clear implementation defect appears, do not fix it. Write
+`<evidence-directory>/acceptance-findings.md` with the tested SHA, affected flow, expected and observed
+behavior, concise reproduction steps, and evidence paths. Do not wait for CI or write final acceptance
+evidence in that invocation. Report the findings and end with the exact line
+`ACCEPTANCE_FIX_NEEDED` so the caller can run its fix and validation loop.
+
+Append product, scope, or design ambiguity to the caller's assumptions ledger with the decision needed
+and likely impact; never silently choose an interpretation or report ambiguity as a clear defect. Every
+invocation re-exercises all supported flows against the current committed `HEAD`; never reuse results
+or screenshots from an earlier invocation.
+
+### 3. Capture visual evidence
+
+For any UI—including web, mobile, desktop, and TUI—store screenshots under
+`<evidence-directory>/acceptance-screenshots/` as the flows are exercised. Capture at least one
+meaningful stable result for every UI flow, and more only when multiple states are needed to understand
+that flow. Do not capture loading, empty, error, responsive, or before/after states unless they are part
+of the flow being tested.
+
+Record for every screenshot:
+
+- flow demonstrated;
+- expected behavior and what the reviewer should notice;
+- route or command, representative input, and user role when relevant;
+- tested head SHA;
+- concise text equivalent.
+
+Screenshots support the observed interaction; they are not proof on their own. For non-visual surfaces,
+retain the corresponding client request/output evidence instead.
+
+### 4. Wait for current-head CI
+
+Invoke `codagent:wait-ci` after a complete flow pass finds no clear defects and the final tested head is
+pushed. Require its report to apply to the exact local and PR head SHA used for the flow pass.
+
+- `passed`: continue.
+- `failed`, `comments`, or `pending`: do not write final acceptance-test or handoff evidence or claim
+  readiness. Report the blocking checks/comments and stop so the caller can route the change through
+  the appropriate fix path.
+- no configured checks: continue only after recording that CI coverage is absent.
+
+Treat skipped, neutral, cancelled, stale, and timed-out checks as explicit evidence states, never as
+proof that associated behavior passed.
+
+### 5. Write acceptance-test evidence
+
+Write `acceptance-test.md` in the evidence directory only after CI passes or is explicitly absent, the
+complete flow pass makes no tracked changes, and the caller's latest automated-validation evidence
+applies to the current pushed head. Include:
+
+- exact tested local/PR head SHA;
+- the supported flows exercised and their outcomes;
+- clear-defect status and any prior workflow fix evidence supplied by the caller;
+- existing automated-validation and CI status without rerunning either;
+- screenshot metadata and text equivalents for every UI flow;
+- representative API, CLI, library, or background-operation evidence for non-UI flows;
+- unavailable flows, environment limitations, warnings, and residual risks;
+- new unresolved assumptions added to the canonical ledger.
+
+Prefer concise conclusions with durable log paths over raw log dumps.
+
+### 6. Prepare the human handoff
+
+Collate existing implementation, acceptance-test, automated-validation, and CI evidence. Do not run new
+acceptance tests, capture replacement screenshots, or fix issues during collation. If evidence is
+missing or stale, stop and require the producing phase to run again.
+
+Write `acceptance-handoff.md` in the evidence directory with:
+
+1. **Decision brief** — unresolved decisions, delivered behavior, overall validation status, known
+   limitations, and suggested human review path.
+2. **Revision identity** — repository, draft PR URL, exact tested SHA, generation time, and tracked
+   worktree status.
+3. **Flow evidence** — each supported flow, what was done, the observed result, its evidence, and any
+   limitation.
+4. **Automated validation and CI** — concise status plus durable logs or links produced by the separate
+   validation and CI steps.
+5. **Visual and client evidence** — screenshot metadata/text equivalents, API or CLI evidence, and
+   practical human review instructions.
+6. **Residual risk** — unavailable flows, environment limitations, warnings, and relevant omissions.
+7. **Assumption handoff** — canonical ledger path plus a concise summary of every unresolved item.
+
+### 7. Verify readiness
+
+Before reporting readiness:
+
+1. Require a clean tracked worktree.
+2. Require local `HEAD`, PR head, `acceptance-test.md`, and `acceptance-handoff.md` to name the same SHA.
+3. Require CI evidence for that SHA to be passing, or explicitly record that no checks exist.
+4. Verify every referenced evidence and screenshot path exists and every UI flow has visual evidence.
+5. Ensure persisted evidence does not expose secrets, credentials, tokens, private data, or unrelated
+   user content.
+6. Confirm the PR remains a draft.
+
+Report the exact ready-for-acceptance SHA, PR URL, handoff path, unresolved-decision count, CI status,
+and known limitations. End with the exact line `ACCEPTANCE_READY`. Do not mark the PR ready or perform
+human acceptance.
+
+## Result protocol
+
+Write the terminal marker to `<evidence-directory>/acceptance-status.txt` as its only non-empty line,
+and return the same marker as the final response line:
+
+- `ACCEPTANCE_FIX_NEEDED` — one or more clear implementation defects were documented for the caller's
+  fix and validation loop. Do not emit final acceptance evidence.
+- `ACCEPTANCE_READY` — no clear defects were found, current-head CI passed or was explicitly absent,
+  and revision-bound evidence was verified.
+- `ACCEPTANCE_BLOCKED: <reason>` — required inputs, testing, PR state, CI, or evidence could not be
+  completed. Do not emit either success marker.
+
+## Out of scope
+
+- Do not obtain human acceptance; leave that to the interactive acceptance workflow.
+- Do not fix implementation defects, modify repository files, commit, push, or alter PR metadata.
+- Do not run automated test suites, linters, builds, or other automated checks; the caller owns them.
+- Do not run automated validation; the caller owns validation and reinvocation.
+- Do not change approved requirements, product scope, or design to make tests pass.
+- Do not archive the change, mark the PR ready, merge, or release.
+- Do not perform fuzzing, adversarial testing, or exhaustive edge-case exploration.
+- Do not treat successful task execution, agent summaries, or screenshots alone as proof of behavior.

--- a/skills/prepare-acceptance/SKILL.md
+++ b/skills/prepare-acceptance/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: >
   Exercises an implemented change through its user and client flows, reports clear defects to a
-  caller-managed fix and validation loop, waits for current-head CI once stable, and prepares concise
-  evidence for human review. Use when preparing a change for acceptance, gathering review evidence,
-  performing human-style flow testing, or when invoked as codagent:prepare-acceptance.
+  caller without fixing them, waits for current-head CI once stable, and prepares concise evidence for
+  human review. Use when preparing a change for acceptance, gathering review evidence, performing
+  human-style flow testing, or when invoked as codagent:prepare-acceptance.
 ---
 
 # Prepare Acceptance
@@ -11,7 +11,7 @@ description: >
 Prepare an implemented change for a separate human acceptance session. Exercise it as a human user or
 real client would, report clear defects, wait for CI once no defects remain, and produce concise
 evidence bound to the exact PR revision. Fixes and automated validation belong to separate
-caller-managed steps.
+caller-managed steps when used.
 
 ## Required inputs
 
@@ -20,12 +20,13 @@ Resolve these from the caller before acting:
 - approved requirements, scenarios, design, and task artifacts;
 - caller-supplied implementation summary or completion evidence identifying delivered behavior;
 - evidence output directory;
-- unresolved-assumptions ledger path, when one exists;
-- required PR state.
+- unresolved-assumptions ledger path, when one exists.
 
 Treat missing source-of-truth artifacts or an unspecified evidence directory as blockers. Do not infer
-product behavior from implementation alone. Keep this workflow autonomous: preserve product, scope,
-or design ambiguity for the later human acceptance session instead of asking the user here.
+product behavior from implementation alone. When no assumptions-ledger path is supplied, use
+`<evidence-directory>/acceptance-assumptions.md` and create it if needed. Keep this preparation
+autonomous: preserve product, scope, or design ambiguity for the later human acceptance session
+instead of asking the user here.
 
 ## Procedure
 
@@ -33,10 +34,10 @@ or design ambiguity for the later human acceptance session instead of asking the
 
 1. Read repository instructions, the approved artifacts, the unresolved-assumptions ledger, and the
    existing automated-validation evidence supplied by the caller.
-2. Record local `HEAD`. Read only the PR URL, current head SHA, and draft state needed for acceptance.
-   Do not inspect or reconstruct a diff.
-3. Require a clean tracked worktree, the required PR state, and local `HEAD` equal to the PR head. If
-   they do not match, stop for the caller to resolve; do not push or alter PR metadata in this skill.
+2. Record local `HEAD`. Read only the PR URL, current head SHA, and current PR state needed for the
+   evidence record. Do not inspect or reconstruct a diff.
+3. Require a clean tracked worktree and local `HEAD` equal to the PR head. If they do not match, stop
+   for the caller to resolve; do not push or alter PR metadata in this skill.
 
 ### 2. Exercise the product like a user
 
@@ -65,10 +66,10 @@ resulting state instead of relying on task completion or agent assertions.
 When a clear implementation defect appears, do not fix it. Write
 `<evidence-directory>/acceptance-findings.md` with the tested SHA, affected flow, expected and observed
 behavior, concise reproduction steps, and evidence paths. Do not wait for CI or write final acceptance
-evidence in that invocation. Report the findings and end with the exact line
-`ACCEPTANCE_FIX_NEEDED` so the caller can run its fix and validation loop.
+evidence in that invocation. Report the findings clearly so the caller can run its fix and validation
+process.
 
-Append product, scope, or design ambiguity to the caller's assumptions ledger with the decision needed
+Append product, scope, or design ambiguity to the resolved assumptions ledger with the decision needed
 and likely impact; never silently choose an interpretation or report ambiguity as a clear defect. Every
 invocation re-exercises all supported flows against the current committed `HEAD`; never reuse results
 or screenshots from an earlier invocation.
@@ -98,9 +99,14 @@ Invoke `codagent:wait-ci` after a complete flow pass finds no clear defects and 
 pushed. Require its report to apply to the exact local and PR head SHA used for the flow pass.
 
 - `passed`: continue.
-- `failed`, `comments`, or `pending`: do not write final acceptance-test or handoff evidence or claim
-  readiness. Report the blocking checks/comments and stop so the caller can route the change through
-  the appropriate fix path.
+- `failed` or `comments`: do not write final acceptance-test or handoff evidence or claim readiness.
+  When the failure or comment is clearly attributable to the implementation and actionable in the
+  repository, add it to `<evidence-directory>/acceptance-findings.md` with the tested SHA, failing
+  check or comment, relevant log or link, and concise expected-versus-observed behavior. Report it as
+  a clear defect so the caller can run its fix and validation process. Otherwise, report the external,
+  environmental, or infrastructure blocker without classifying it as an implementation defect.
+- `pending`: do not claim readiness. Report the pending checks and stop for the caller to resume or
+  retry later.
 - no configured checks: continue only after recording that CI coverage is absent.
 
 Treat skipped, neutral, cancelled, stale, and timed-out checks as explicit evidence states, never as
@@ -109,13 +115,15 @@ proof that associated behavior passed.
 ### 5. Write acceptance-test evidence
 
 Write `acceptance-test.md` in the evidence directory only after CI passes or is explicitly absent, the
-complete flow pass makes no tracked changes, and the caller's latest automated-validation evidence
-applies to the current pushed head. Include:
+complete flow pass makes no tracked changes, and any automated-validation evidence supplied by the
+caller applies to the current pushed head. Do not require automated-validation evidence when none was
+supplied; explicitly record its absence instead. Include:
 
 - exact tested local/PR head SHA;
 - the supported flows exercised and their outcomes;
-- clear-defect status and any prior workflow fix evidence supplied by the caller;
-- existing automated-validation and CI status without rerunning either;
+- clear-defect status and any prior fix evidence supplied by the caller;
+- existing automated-validation and CI status without rerunning either, explicitly noting when
+  automated-validation evidence was not supplied;
 - screenshot metadata and text equivalents for every UI flow;
 - representative API, CLI, library, or background-operation evidence for non-UI flows;
 - unavailable flows, environment limitations, warnings, and residual risks;
@@ -125,20 +133,21 @@ Prefer concise conclusions with durable log paths over raw log dumps.
 
 ### 6. Prepare the human handoff
 
-Collate existing implementation, acceptance-test, automated-validation, and CI evidence. Do not run new
-acceptance tests, capture replacement screenshots, or fix issues during collation. If evidence is
-missing or stale, stop and require the producing phase to run again.
+Collate existing implementation, acceptance-test, available automated-validation, and CI evidence. Do
+not run new acceptance tests, capture replacement screenshots, or fix issues during collation. If
+required evidence is missing or stale, stop and require the producing phase to run again. The explicit
+absence of caller-supplied automated-validation evidence is not missing evidence.
 
 Write `acceptance-handoff.md` in the evidence directory with:
 
 1. **Decision brief** — unresolved decisions, delivered behavior, overall validation status, known
    limitations, and suggested human review path.
-2. **Revision identity** — repository, draft PR URL, exact tested SHA, generation time, and tracked
+2. **Revision identity** — repository, PR URL, exact tested SHA, generation time, and tracked
    worktree status.
 3. **Flow evidence** — each supported flow, what was done, the observed result, its evidence, and any
    limitation.
-4. **Automated validation and CI** — concise status plus durable logs or links produced by the separate
-   validation and CI steps.
+4. **Automated validation and CI** — concise status plus durable logs or links produced by separate
+   validation and CI steps; explicitly say when automated-validation evidence was not supplied.
 5. **Visual and client evidence** — screenshot metadata/text equivalents, API or CLI evidence, and
    practical human review instructions.
 6. **Residual risk** — unavailable flows, environment limitations, warnings, and relevant omissions.
@@ -154,30 +163,18 @@ Before reporting readiness:
 4. Verify every referenced evidence and screenshot path exists and every UI flow has visual evidence.
 5. Ensure persisted evidence does not expose secrets, credentials, tokens, private data, or unrelated
    user content.
-6. Confirm the PR remains a draft.
+6. Record the current PR state for the caller without changing it.
 
 Report the exact ready-for-acceptance SHA, PR URL, handoff path, unresolved-decision count, CI status,
-and known limitations. End with the exact line `ACCEPTANCE_READY`. Do not mark the PR ready or perform
-human acceptance.
-
-## Result protocol
-
-Write the terminal marker to `<evidence-directory>/acceptance-status.txt` as its only non-empty line,
-and return the same marker as the final response line:
-
-- `ACCEPTANCE_FIX_NEEDED` — one or more clear implementation defects were documented for the caller's
-  fix and validation loop. Do not emit final acceptance evidence.
-- `ACCEPTANCE_READY` — no clear defects were found, current-head CI passed or was explicitly absent,
-  and revision-bound evidence was verified.
-- `ACCEPTANCE_BLOCKED: <reason>` — required inputs, testing, PR state, CI, or evidence could not be
-  completed. Do not emit either success marker.
+and known limitations. Do not mark the PR ready or perform human acceptance. The caller owns any
+machine-readable status file, terminal marker, or control-flow protocol.
 
 ## Out of scope
 
-- Do not obtain human acceptance; leave that to the interactive acceptance workflow.
+- Do not obtain human acceptance; leave that to the later human acceptance session.
 - Do not fix implementation defects, modify repository files, commit, push, or alter PR metadata.
-- Do not run automated test suites, linters, builds, or other automated checks; the caller owns them.
-- Do not run automated validation; the caller owns validation and reinvocation.
+- Do not run automated test suites, linters, builds, other automated checks, or automated validation;
+  the caller owns validation and reinvocation.
 - Do not change approved requirements, product scope, or design to make tests pass.
 - Do not archive the change, mark the PR ready, merge, or release.
 - Do not perform fuzzing, adversarial testing, or exhaustive edge-case exploration.

--- a/skills/prepare-acceptance/agents/openai.yaml
+++ b/skills/prepare-acceptance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare Acceptance"
+  short_description: "Exercise product flows and package review evidence"
+  default_prompt: "Use $prepare-acceptance to exercise the implemented user and client flows, wait for CI, and prepare evidence for human acceptance."

--- a/skills/wait-ci/SKILL.md
+++ b/skills/wait-ci/SKILL.md
@@ -57,6 +57,7 @@ The script outputs a JSON object with these fields:
 | `status` | string | `passed`, `failed`, `pending`, `no_checks`, or `comments` (set by caller) |
 | `pr_url` | string | PR URL |
 | `pr_number` | number | PR number |
+| `head_sha` | string | PR head commit queried for this invocation; preserve it when upgrading the status to `comments` |
 | `owner` / `repo` | string | Repo coordinates for subsequent calls |
 | `had_checks` | bool | Whether any checks were seen on this invocation |
 | `failed_checks` | array | Checks with `bucket == "fail"` |

--- a/skills/wait-ci/SKILL.md
+++ b/skills/wait-ci/SKILL.md
@@ -28,7 +28,7 @@ Compute `max_runs = ceil(max_minutes * 60 / 90)`, defaulting to `max_minutes = 1
 
 The skill accepts an optional `--max-minutes N` argument; pass it through to adjust `max_runs`.
 
-Track `ever_had_checks = false` and `run = 0` across iterations.
+Track `ever_had_checks = false`, `run = 0`, and the overall deadline across iterations. The deadline is `max_minutes` after polling starts and also bounds any review-bot waiting in Step 3.
 
 For each run:
 
@@ -90,7 +90,14 @@ Output fields:
 |---|---|---|
 | `has_comments` | bool | True if any unaddressed comments exist |
 | `unresolved_threads` | array | `{file, line, author, body}` per unresolved review thread |
-| `issue_comments` | array | `{author, body}` top-level PR comments (excluding PR creator) |
+| `issue_comments` | array | `{author, body}` blocking top-level human comments (excluding PR creator) |
+| `informational_bot_comments` | array | `{author, body}` non-blocking top-level bot comments retained as evidence |
+
+Unresolved review threads are blocking regardless of author. Top-level bot comments do not set `has_comments`; only unresolved threads and human top-level comments do.
+
+After checks are terminal, inspect `informational_bot_comments`. If a bot explicitly reports that its review is pending or in progress, or asks the caller to check back, wait 10 seconds and call `get-pr-comments.sh` again while time remains before the overall deadline. Re-evaluate the latest evidence on every poll. Do not hard-code bot vendors or exact phrases; use the comment's meaning. Completed summaries and ordinary status notices remain informational and do not delay completion.
+
+If a bot still explicitly reports unfinished review work when the overall deadline is reached, report `pending`. Preserve its comment in the output so the reason is visible. Never extend the overall deadline while waiting for review bots.
 
 **Status upgrade:** If checks returned `passed` but `get-pr-comments.sh` returns `has_comments: true`, report the final status as `comments`.
 
@@ -119,6 +126,9 @@ Output fields:
 - **<author>** on `<file>` line <N>: <comment body>
 - **<author>** (issue comment): <comment body>
 
+### Informational Bot Comments
+- **<author>**: <comment body>
+
 ### Passing Checks
 - <check-name> (SUCCESS)
 
@@ -127,10 +137,10 @@ Output fields:
 ```
 
 Status meanings:
-- `passed` — CI green, no blocking reviews, no PR comments
+- `passed` — CI green, no blocking reviews or comments, and no bot review still in progress
 - `failed` — CI failures or `CHANGES_REQUESTED` reviews (with logs)
 - `comments` — CI green but unresolved PR comments need addressing
-- `pending` — checks still running after max wait (list which ones)
+- `pending` — checks or an explicitly unfinished bot review remain after max wait
 
 ## Notes
 
@@ -146,4 +156,4 @@ Status meanings:
 | Script | Purpose |
 |---|---|
 | `scripts/check-ci.sh` | Single-invocation poller (90s, 10s interval) — call in a loop from the skill |
-| `scripts/get-pr-comments.sh` | GraphQL comment fetcher — returns unresolved threads and issue comments |
+| `scripts/get-pr-comments.sh` | GraphQL comment fetcher — returns blocking review feedback and informational bot comments |

--- a/skills/wait-ci/scripts/check-ci.sh
+++ b/skills/wait-ci/scripts/check-ci.sh
@@ -18,6 +18,7 @@
 #   status          "passed" | "failed" | "pending" | "no_checks"
 #   pr_url          PR URL
 #   pr_number       PR number
+#   head_sha        PR head commit queried for this invocation
 #   owner / repo    Repo coordinates for subsequent calls
 #   had_checks      bool — whether any checks were seen on this invocation
 #   checks          all checks from the last poll
@@ -55,12 +56,16 @@ MAX_POLLS=$(( (MAX_SECONDS + INTERVAL - 1) / INTERVAL ))
 [[ $MAX_POLLS -lt 1 ]] && MAX_POLLS=1
 
 # ── Find PR ───────────────────────────────────────────────────────────────────
-pr_json=$(gh pr view --json number,url,headRefName 2>/dev/null) || {
+pr_json=$(gh pr view --json number,url,headRefName,headRefOid 2>/dev/null) || {
   echo '{"error":"no PR found for current branch"}' >&2
   exit 1
 }
 pr_number=$(echo "$pr_json" | jq '.number')
 pr_url=$(echo "$pr_json" | jq -r '.url')
+head_sha=$(echo "$pr_json" | jq -er '.headRefOid | strings | select(length > 0)') || {
+  echo '{"error":"PR head SHA is missing"}' >&2
+  exit 1
+}
 
 # ── Repo info ─────────────────────────────────────────────────────────────────
 repo_json=$(gh repo view --json owner,name 2>/dev/null) || {
@@ -142,6 +147,7 @@ while [[ $poll -lt $MAX_POLLS ]]; do
       --arg     status           "failed" \
       --arg     pr_url           "$pr_url" \
       --argjson pr_number        "$pr_number" \
+      --arg     head_sha         "$head_sha" \
       --arg     owner            "$owner" \
       --arg     repo             "$repo" \
       --argjson had_checks       "$( [[ $had_checks == true ]] && echo true || echo false )" \
@@ -152,7 +158,7 @@ while [[ $poll -lt $MAX_POLLS ]]; do
       --argjson blocking_reviews "$blocking_reviews" \
       --argjson failed_run_ids   "$failed_run_ids_json" \
       '{
-        status: $status, pr_url: $pr_url, pr_number: $pr_number,
+        status: $status, pr_url: $pr_url, pr_number: $pr_number, head_sha: $head_sha,
         owner: $owner, repo: $repo, had_checks: $had_checks,
         checks: $checks, failed_checks: $failed_checks,
         passed_checks: $passed_checks, pending_checks: $pending_checks,
@@ -167,13 +173,14 @@ while [[ $poll -lt $MAX_POLLS ]]; do
       --arg     status          "passed" \
       --arg     pr_url          "$pr_url" \
       --argjson pr_number       "$pr_number" \
+      --arg     head_sha        "$head_sha" \
       --arg     owner           "$owner" \
       --arg     repo            "$repo" \
       --argjson had_checks      true \
       --argjson checks          "$checks_json" \
       --argjson passed_checks   "$passed_checks" \
       '{
-        status: $status, pr_url: $pr_url, pr_number: $pr_number,
+        status: $status, pr_url: $pr_url, pr_number: $pr_number, head_sha: $head_sha,
         owner: $owner, repo: $repo, had_checks: $had_checks,
         checks: $checks, failed_checks: [], passed_checks: $passed_checks,
         pending_checks: [], blocking_reviews: [], failed_run_ids: []
@@ -193,13 +200,14 @@ jq -n \
   --arg     status          "$( [[ $had_checks == true ]] && echo "pending" || echo "no_checks" )" \
   --arg     pr_url          "$pr_url" \
   --argjson pr_number       "$pr_number" \
+  --arg     head_sha        "$head_sha" \
   --arg     owner           "$owner" \
   --arg     repo            "$repo" \
   --argjson had_checks      "$( [[ $had_checks == true ]] && echo true || echo false )" \
   --argjson checks          "$checks_json" \
   --argjson pending_checks  "$pending_checks" \
   '{
-    status: $status, pr_url: $pr_url, pr_number: $pr_number,
+    status: $status, pr_url: $pr_url, pr_number: $pr_number, head_sha: $head_sha,
     owner: $owner, repo: $repo, had_checks: $had_checks,
     checks: $checks, failed_checks: [], passed_checks: [],
     pending_checks: $pending_checks, blocking_reviews: [], failed_run_ids: []

--- a/skills/wait-ci/scripts/get-pr-comments.sh
+++ b/skills/wait-ci/scripts/get-pr-comments.sh
@@ -10,17 +10,20 @@
 # {
 #   "has_comments": true | false,
 #   "unresolved_threads": [...],    # inline review threads not yet resolved
-#   "issue_comments": [...]         # top-level PR conversation comments
+#   "issue_comments": [...],        # blocking top-level human comments
+#   "informational_bot_comments": [...] # non-blocking top-level bot comments
 # }
 #
 # Each unresolved_thread entry:
 # { "file": "...", "line": N, "author": "...", "body": "..." }
 #
-# Each issue_comment entry:
+# Each issue_comment and informational_bot_comment entry:
 # { "author": "...", "body": "..." }
 #
 # Notes:
-# - Only returns comments NOT authored by the PR creator (pass pr-author-login to exclude).
+# - Unresolved review threads always block, regardless of author type.
+# - Top-level comments by the PR creator are omitted.
+# - Top-level bot comments are returned as informational evidence, not blockers.
 # - Resolved threads are omitted.
 # - Fetches up to 100 review threads and 100 issue comments.
 
@@ -42,13 +45,13 @@ query='
 query($owner: String!, $repo: String!, $prNumber: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
-      author { login }
+      author { __typename login }
       reviewThreads(first: 100) {
         nodes {
           isResolved
           comments(first: 10) {
             nodes {
-              author { login }
+              author { __typename login }
               body
               path
               line
@@ -59,7 +62,7 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
       }
       comments(first: 100) {
         nodes {
-          author { login }
+          author { __typename login }
           body
         }
       }
@@ -82,9 +85,9 @@ fi
 # ── Unresolved review threads ─────────────────────────────────────────────────
 # Filter to threads where isResolved == false, then take the first comment's
 # metadata (file, line) and all comment bodies.
-unresolved_threads=$(echo "$result" | jq --arg pr_author "$PR_AUTHOR" '
+unresolved_threads=$(echo "$result" | jq '
   [
-    .data.repository.pullRequest.reviewThreads.nodes[]
+    .data.repository.pullRequest.reviewThreads.nodes[]?
     | select(.isResolved == false)
     | .comments.nodes as $comments
     | ($comments | first) as $first
@@ -94,15 +97,27 @@ unresolved_threads=$(echo "$result" | jq --arg pr_author "$PR_AUTHOR" '
         author: ($first.author.login // "unknown"),
         body: ($first.body // "")
       }
-    | select(.author != $pr_author)
   ]
 ')
 
-# ── Issue-level comments ──────────────────────────────────────────────────────
+# ── Top-level human comments ──────────────────────────────────────────────────
+# Only explicit Bot actors are informational. Missing or unfamiliar actor types
+# remain blocking so unavailable author metadata cannot hide feedback.
 issue_comments=$(echo "$result" | jq --arg pr_author "$PR_AUTHOR" '
   [
-    .data.repository.pullRequest.comments.nodes[]
-    | select((.author.login // "") != $pr_author)
+    .data.repository.pullRequest.comments.nodes[]?
+    | select($pr_author == "" or (.author.login // "") != $pr_author)
+    | select((.author.__typename // "") != "Bot")
+    | { author: (.author.login // "unknown"), body: (.body // "") }
+  ]
+')
+
+# ── Top-level bot comments ────────────────────────────────────────────────────
+informational_bot_comments=$(echo "$result" | jq --arg pr_author "$PR_AUTHOR" '
+  [
+    .data.repository.pullRequest.comments.nodes[]?
+    | select($pr_author == "" or (.author.login // "") != $pr_author)
+    | select((.author.__typename // "") == "Bot")
     | { author: (.author.login // "unknown"), body: (.body // "") }
   ]
 ')
@@ -116,8 +131,10 @@ jq -n \
   --argjson has_comments        "$([ "$has_comments" -gt 0 ] && echo true || echo false)" \
   --argjson unresolved_threads  "$unresolved_threads" \
   --argjson issue_comments      "$issue_comments" \
+  --argjson informational_bot_comments "$informational_bot_comments" \
   '{
     has_comments: $has_comments,
     unresolved_threads: $unresolved_threads,
-    issue_comments: $issue_comments
+    issue_comments: $issue_comments,
+    informational_bot_comments: $informational_bot_comments
   }'

--- a/skills/wait-ci/scripts/get-pr-comments_test.sh
+++ b/skills/wait-ci/scripts/get-pr-comments_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="$SCRIPT_DIR/get-pr-comments.sh"
+MOCK_BIN=$(mktemp -d)
+trap 'rm -rf "$MOCK_BIN"' EXIT
+
+cat >"$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" != *"__typename"* ]]; then
+  echo "GraphQL query did not request author __typename" >&2
+  exit 1
+fi
+
+printf '%s\n' "$MOCK_GRAPHQL_RESPONSE"
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+run_script() {
+  PATH="$MOCK_BIN:$PATH" MOCK_GRAPHQL_RESPONSE="$1" \
+    bash "$SCRIPT" owner repo 42 pr-author
+}
+
+only_bot_comments='{"data":{"repository":{"pullRequest":{"author":{"login":"pr-author","__typename":"User"},"reviewThreads":{"nodes":[]},"comments":{"nodes":[{"author":{"login":"qodo-merge-pro[bot]","__typename":"Bot"},"body":"Analysis summary"}]}}}}}'
+result=$(run_script "$only_bot_comments")
+jq -e '.has_comments == false' <<<"$result" >/dev/null
+jq -e '.issue_comments == []' <<<"$result" >/dev/null
+jq -e '.informational_bot_comments == [{"author":"qodo-merge-pro[bot]","body":"Analysis summary"}]' <<<"$result" >/dev/null
+
+human_comment='{"data":{"repository":{"pullRequest":{"author":{"login":"pr-author","__typename":"User"},"reviewThreads":{"nodes":[]},"comments":{"nodes":[{"author":{"login":"reviewer","__typename":"User"},"body":"Please update this."}]}}}}}'
+result=$(run_script "$human_comment")
+jq -e '.has_comments == true' <<<"$result" >/dev/null
+jq -e '.issue_comments == [{"author":"reviewer","body":"Please update this."}]' <<<"$result" >/dev/null
+jq -e '.informational_bot_comments == []' <<<"$result" >/dev/null
+
+unresolved_bot_thread='{"data":{"repository":{"pullRequest":{"author":{"login":"pr-author","__typename":"User"},"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"qodo-merge-pro[bot]","__typename":"Bot"},"body":"Potential bug","path":"script.sh","line":12,"originalLine":null}]}}]},"comments":{"nodes":[]}}}}}'
+result=$(run_script "$unresolved_bot_thread")
+jq -e '.has_comments == true' <<<"$result" >/dev/null
+jq -e '.unresolved_threads == [{"file":"script.sh","line":12,"author":"qodo-merge-pro[bot]","body":"Potential bug"}]' <<<"$result" >/dev/null
+
+pr_author_comment='{"data":{"repository":{"pullRequest":{"author":{"login":"pr-author","__typename":"User"},"reviewThreads":{"nodes":[]},"comments":{"nodes":[{"author":{"login":"pr-author","__typename":"User"},"body":"Context from the author"}]}}}}}'
+result=$(run_script "$pr_author_comment")
+jq -e '.has_comments == false' <<<"$result" >/dev/null
+jq -e '.issue_comments == []' <<<"$result" >/dev/null
+jq -e '.informational_bot_comments == []' <<<"$result" >/dev/null
+
+missing_author='{"data":{"repository":{"pullRequest":{"author":{"login":"pr-author","__typename":"User"},"reviewThreads":{"nodes":[]},"comments":{"nodes":[{"author":null,"body":"Comment from a deleted account"}]}}}}}'
+result=$(run_script "$missing_author")
+jq -e '.has_comments == true' <<<"$result" >/dev/null
+jq -e '.issue_comments == [{"author":"unknown","body":"Comment from a deleted account"}]' <<<"$result" >/dev/null
+
+echo "get-pr-comments tests passed"


### PR DESCRIPTION
## Summary

- add a reusable prepare-acceptance skill for human-style flow testing and review evidence
- keep fix, validation, PR-state, and result-control policy with callers
- route actionable CI findings back to caller-managed correction loops
- bind wait-ci results and acceptance evidence to the exact PR head SHA
- distinguish blocking review feedback from informational and still-running bot reviews
- release the Agent Skills bundle as v0.8.0

## Validation

- Agent Validator skill-quality review passed
- focused mocked-gh checks cover CI result shapes and bot/human comment classification
- shell syntax, shellcheck where available, and diff checks passed